### PR TITLE
Downgrade Kotlin to 1.6.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,13 +52,13 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <kotlin.version>1.9.10</kotlin.version>
+        <kotlin.version>1.6.21</kotlin.version>
+        <dokka.version>${kotlin.version}</dokka.version>
 
         <axon.version>4.6.7</axon.version>
 
         <projectreactor.version>3.5.10</projectreactor.version>
         <spring-boot.version>2.7.15</spring-boot.version>
-        <dokka.version>1.9.0</dokka.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
It has come to our attention that when compiling the project with kotlin 1.9, projects using Kotlin 1.7.x and lower run into problems compiling.

This PR adjusts the Kotlin version to 1.6.21 (latest in 1.6.x) which should make it compatible with Kotlin 1.5.x, of which 1.5.0 was released in May 2021. This should provide sufficient backwards compatibility.