### PR TITLE
Make the client compatible with AF 4.9.

### DIFF
--- a/console-framework-client-spring-boot-starter/src/main/java/io/axoniq/console/framework/starter/AxoniqConsoleAutoConfiguration.kt
+++ b/console-framework-client-spring-boot-starter/src/main/java/io/axoniq/console/framework/starter/AxoniqConsoleAutoConfiguration.kt
@@ -18,8 +18,8 @@ package io.axoniq.console.framework.starter
 
 import io.axoniq.console.framework.AxoniqConsoleConfigurerModule
 import io.axoniq.console.framework.messaging.AxoniqConsoleSpanFactory
+import io.axoniq.console.framework.messaging.SpanMatcher.Companion.getSpanMatcherPredicateMap
 import io.axoniq.console.framework.messaging.SpanMatcherPredicateMap
-import io.axoniq.console.framework.messaging.getSpanMatcherPredicateMap
 import org.axonframework.config.ConfigurerModule
 import org.axonframework.tracing.MultiSpanFactory
 import org.axonframework.tracing.NoOpSpanFactory

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/AxoniqConsoleConfigurerModule.java
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/AxoniqConsoleConfigurerModule.java
@@ -51,7 +51,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
-import static io.axoniq.console.framework.messaging.SpanMatcherKt.getSpanMatcherPredicateMap;
+import static io.axoniq.console.framework.messaging.SpanMatcher.getSpanMatcherPredicateMap;
 
 /**
  * Applies the configuration necessary for AxonIQ Console to the {@link Configurer} of Axon Framework.

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/DeadLetterManager.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/DeadLetterManager.kt
@@ -24,8 +24,9 @@ import org.axonframework.messaging.MetaData
 import org.axonframework.messaging.deadletter.DeadLetter
 import org.axonframework.messaging.deadletter.SequencedDeadLetterQueue
 import org.axonframework.serialization.Serializer
-import java.util.concurrent.*
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.TimeUnit
 import io.axoniq.console.framework.api.DeadLetter as ApiDeadLetter
 
 private const val LETTER_PAYLOAD_SIZE_LIMIT = 1024

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/RSocketProcessorResponder.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/RSocketProcessorResponder.kt
@@ -16,7 +16,10 @@
 
 package io.axoniq.console.framework.eventprocessor
 
-import io.axoniq.console.framework.api.*
+import io.axoniq.console.framework.api.ProcessorSegmentId
+import io.axoniq.console.framework.api.ProcessorStatusReport
+import io.axoniq.console.framework.api.ResetDecision
+import io.axoniq.console.framework.api.SegmentOverview
 import io.axoniq.console.framework.client.RSocketHandlerRegistrar
 import org.axonframework.lifecycle.Lifecycle
 import org.axonframework.lifecycle.Phase

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/AxoniqConsoleDispatchInterceptor.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/AxoniqConsoleDispatchInterceptor.kt
@@ -16,8 +16,8 @@
 
 package io.axoniq.console.framework.messaging
 
-import io.axoniq.console.framework.api.ComponentPayload
 import io.axoniq.console.framework.api.AxoniqConsoleMessageOrigin
+import io.axoniq.console.framework.api.ComponentPayload
 import io.axoniq.console.framework.api.metrics.DispatcherStatisticIdentifier
 import io.axoniq.console.framework.api.metrics.HandlerStatisticsMetricIdentifier
 import io.axoniq.console.framework.api.metrics.HandlerType

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/HandlerMetricsRegistry.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/HandlerMetricsRegistry.kt
@@ -41,7 +41,7 @@ class HandlerMetricsRegistry(
     private val handlers: MutableMap<HandlerStatisticsMetricIdentifier, HandlerRegistryStatistics> = ConcurrentHashMap()
     private val aggregates: MutableMap<AggregateStatisticIdentifier, AggregateRegistryStatistics> = ConcurrentHashMap()
 
-    private val noHanlerIdentifier = HandlerStatisticsMetricIdentifier(HandlerType.Origin, "application", MessageIdentifier("Dispatcher", componentName))
+    private val noHandlerIdentifier = HandlerStatisticsMetricIdentifier(HandlerType.Origin, "application", MessageIdentifier("Dispatcher", componentName))
 
     override fun registerLifecycleHandlers(lifecycle: Lifecycle.LifecycleRegistry) {
         lifecycle.onStart(Phase.INSTRUCTION_COMPONENTS, this::start)
@@ -173,7 +173,7 @@ class HandlerMetricsRegistry(
     fun registerMessageDispatchedWithoutHandling(
             message: MessageIdentifier,
     ) {
-        dispatches.computeIfAbsentWithRetry(DispatcherStatisticIdentifier(noHanlerIdentifier, message)) { _ ->
+        dispatches.computeIfAbsentWithRetry(DispatcherStatisticIdentifier(noHandlerIdentifier, message)) { _ ->
             RollingCountMeasure()
         }.increment()
     }

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/SpanMatcher.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/SpanMatcher.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2022-2023. AxonIQ B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.axoniq.console.framework.messaging
+
+import org.axonframework.util.MavenArtifactVersionResolver
+import java.util.*
+import java.util.function.Predicate
+
+/**
+ * Enum used by the {@link AxoniqConsoleSpanFactory} to determine if it should call certain methods, bases on the span
+ * name. This makes it possible to support the way spans are implemented by default for version 4.6 to 4.8 as well as
+ * the version from 4.9. It also makes it possible to accommodate for custom span implementations.
+ */
+enum class SpanMatcher(val pre49Predicate: Predicate<String>, val from49Predicate: Predicate<String>) {
+    HANDLER(
+            Predicate { name: String ->
+                name == "QueryProcessingTask" ||
+                        name == "AxonServerCommandBus.handle" ||
+                        name == "DeadlineJob.execute"
+            },
+            Predicate { name: String ->
+                name == "QueryBus.processQueryMessage" ||
+                        name == "CommandBus.handleCommand" ||
+                        name.startsWith("DeadlineManager.executeDeadline(")
+            }),
+    OBTAIN_LOCK(
+            Predicate { name: String -> name == "LockingRepository.obtainLock" },
+            Predicate { name: String -> name == "Repository.obtainLock" }),
+    LOAD(
+            Predicate { name: String -> name.contains(".load ") },
+            Predicate { name: String -> name == "Repository.load" }),
+    COMMIT(
+            Predicate { name: String -> name.endsWith(".commit") },
+            Predicate { name: String -> name == "EventBus.commitEvents" }),
+    MESSAGE_START(
+            Predicate { name: String ->
+                name.endsWith("Bus.handle")
+                        || name == "SimpleQueryBus.query"
+                        || name.startsWith("SimpleQueryBus.scatterGather")
+                        || name.startsWith("PooledStreamingEventProcessor")
+                        || name.startsWith("TrackingEventProcessor")
+            },
+            Predicate { name: String ->
+                name == "CommandBus.dispatchCommand"
+                        || name == "QueryBus.query"
+                        || name.startsWith("QueryBus.scatterGatherQuery")
+                        || name.startsWith("StreamingEventProcessor")
+            })
+}
+
+class SpanMatcherPredicateMap : EnumMap<SpanMatcher, Predicate<String>>(SpanMatcher::class.java)
+
+private fun pre49PredicateMap(): SpanMatcherPredicateMap {
+    val spanMatcherPredicateMap = SpanMatcherPredicateMap()
+    SpanMatcher.values().forEach { s -> spanMatcherPredicateMap[s] = s.pre49Predicate }
+    return spanMatcherPredicateMap
+}
+
+private fun from49PredicateMap(): SpanMatcherPredicateMap {
+    val spanMatcherPredicateMap = SpanMatcherPredicateMap()
+    SpanMatcher.values().forEach { s -> spanMatcherPredicateMap[s] = s.from49Predicate }
+    return spanMatcherPredicateMap
+}
+
+private fun pre49Version(): Boolean {
+    val version = MavenArtifactVersionResolver(
+            "org.axonframework",
+            "axon-messaging",
+            SpanMatcher::class.java.classLoader
+    ).get() ?: "Unknown"
+    return version.startsWith("4.6") || version.startsWith("4.7") || version.startsWith("4.8")
+}
+
+/**
+ * Get the mapping for the spans, based on the version of axon-messaging.
+ */
+fun getSpanMatcherPredicateMap(): SpanMatcherPredicateMap =
+        if (pre49Version())
+            pre49PredicateMap()
+        else
+            from49PredicateMap()

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/utils.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/utils.kt
@@ -17,7 +17,6 @@ package io.axoniq.console.framework
 
 import org.axonframework.common.ReflectionUtils
 import java.lang.reflect.Field
-import kotlin.reflect.KClass
 
 /**
  * Find fields matching its own type. If found, it will unwrap the deeper value.


### PR DESCRIPTION
Make the client compatible with 4.9, and also make it configurable for when the spans were customized.
Most work is done by the SpanMatcher enum, which provides an abstraction to determine, based on the name of the span, if the span factory should do certain things. This makes it both compatible with framework version before 4.9 as well as versions from 4.9.
It also adds an `createChildHandlerSpan` overwrite to the span factory in order to properly handle the 4.9 default way of setting the spans in a streaming event processor.
It was tested with a gift card app, where all the messages show up. It might still miss things through.
It contains a few formatting changes, I'm not sure why through, as the `EditorConfig` plugin is enabled.