### PR TITLE
Introduce the hearbeat mechanism

### DIFF
--- a/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/Routes.kt
+++ b/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/Routes.kt
@@ -18,6 +18,10 @@ package io.axoniq.console.framework.api
 
 object Routes {
 
+    object Management {
+        const val HEARTBEAT = "heartbeat"
+    }
+
     object EventProcessor {
         const val REPORT = "processor-info-report"
 

--- a/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/Routes.kt
+++ b/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/Routes.kt
@@ -19,7 +19,10 @@ package io.axoniq.console.framework.api
 object Routes {
 
     object Management {
-        const val HEARTBEAT = "heartbeat"
+        // Route on both client and server. Client can pull settings whenever, server can push new settings
+        const val SETTINGS = "client-settings"
+        // Route on both client and server to receive/send heartbeats
+        const val HEARTBEAT = "client-heartbeat"
     }
 
     object EventProcessor {

--- a/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/clientApi.kt
+++ b/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/clientApi.kt
@@ -1,0 +1,8 @@
+package io.axoniq.console.framework.api
+
+data class ClientSettings(
+        val heartbeatInterval: Long,
+        val heartbeatTimeout: Long,
+        val processorReportInterval: Long,
+        val handlerReportInterval: Long,
+)

--- a/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/clientIdentification.kt
+++ b/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/clientIdentification.kt
@@ -83,12 +83,17 @@ data class ConsoleClientIdentifier(
 )
 
 data class SetupPayload(
-    val commandBus: CommandBusInformation,
-    val queryBus: QueryBusInformation,
-    val eventStore: EventStoreInformation,
-    val processors: List<ProcessorInformation>,
-    val versions: Versions,
-    val upcasters: List<String>,
+        val features: SupportedFeatures? = SupportedFeatures(),
+        val commandBus: CommandBusInformation,
+        val queryBus: QueryBusInformation,
+        val eventStore: EventStoreInformation,
+        val processors: List<ProcessorInformation>,
+        val versions: Versions,
+        val upcasters: List<String>,
+)
+
+data class SupportedFeatures(
+        val heartbeat: Boolean? = false,
 )
 
 data class Versions(

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/AxoniqConsoleConfigurerModule.java
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/AxoniqConsoleConfigurerModule.java
@@ -151,7 +151,8 @@ public class AxoniqConsoleConfigurerModule implements ConfigurerModule {
                                 c.getComponent(RSocketHandlerRegistrar.class),
                                 c.getComponent(RSocketPayloadEncodingStrategy.class),
                                 reportingTaskExecutor,
-                                ManagementFactory.getRuntimeMXBean().getName()
+                                ManagementFactory.getRuntimeMXBean().getName(),
+                                30
                         )
                 )
                 .registerComponent(ServerProcessorReporter.class,

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/AxoniqConsoleConfigurerModule.java
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/AxoniqConsoleConfigurerModule.java
@@ -17,6 +17,7 @@
 package io.axoniq.console.framework;
 
 import io.axoniq.console.framework.client.AxoniqConsoleRSocketClient;
+import io.axoniq.console.framework.client.ClientSettingsService;
 import io.axoniq.console.framework.client.RSocketHandlerRegistrar;
 import io.axoniq.console.framework.client.ServerProcessorReporter;
 import io.axoniq.console.framework.client.SetupPayloadCreator;
@@ -107,6 +108,9 @@ public class AxoniqConsoleConfigurerModule implements ConfigurerModule {
     @Override
     public void configureModule(@NotNull Configurer configurer) {
         configurer
+                .registerComponent(ClientSettingsService.class,
+                        c -> new ClientSettingsService()
+                )
                 .registerComponent(ProcessorMetricsRegistry.class,
                         c -> new ProcessorMetricsRegistry()
                 )
@@ -150,20 +154,22 @@ public class AxoniqConsoleConfigurerModule implements ConfigurerModule {
                                 c.getComponent(SetupPayloadCreator.class),
                                 c.getComponent(RSocketHandlerRegistrar.class),
                                 c.getComponent(RSocketPayloadEncodingStrategy.class),
+                                c.getComponent(ClientSettingsService.class),
                                 reportingTaskExecutor,
-                                ManagementFactory.getRuntimeMXBean().getName(),
-                                30
+                                ManagementFactory.getRuntimeMXBean().getName()
                         )
                 )
                 .registerComponent(ServerProcessorReporter.class,
                         c -> new ServerProcessorReporter(
                                 c.getComponent(AxoniqConsoleRSocketClient.class),
                                 c.getComponent(ProcessorReportCreator.class),
+                                c.getComponent(ClientSettingsService.class),
                                 reportingTaskExecutor)
                 )
                 .registerComponent(HandlerMetricsRegistry.class,
                         c -> new HandlerMetricsRegistry(
                                 c.getComponent(AxoniqConsoleRSocketClient.class),
+                                c.getComponent(ClientSettingsService.class),
                                 reportingTaskExecutor,
                                 applicationName
                         )

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/client/AxoniqConsoleRSocketClient.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/client/AxoniqConsoleRSocketClient.kt
@@ -16,9 +16,11 @@
 
 package io.axoniq.console.framework.client
 
+import io.axoniq.console.framework.api.Routes
 import io.axoniq.console.framework.client.strategy.RSocketPayloadEncodingStrategy
 import io.netty.buffer.ByteBufAllocator
 import io.netty.buffer.CompositeByteBuf
+import io.rsocket.Payload
 import io.rsocket.RSocket
 import io.rsocket.core.RSocketConnector
 import io.rsocket.metadata.WellKnownMimeType
@@ -28,10 +30,22 @@ import org.axonframework.lifecycle.Phase
 import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 import reactor.netty.tcp.TcpClient
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
+import kotlin.math.pow
 
+/**
+ * The beating heart of the Console client. This class is responsible for connecting to the Console, and keeping
+ * the connection alive. It will also ensure that the connection is re-established in case of a disconnect.
+ *
+ * The server will send heartbeats to the client every 10 seconds. Upon not receiving heartbeats for 32 seconds
+ * (missing three of them) we can be sure the connection is dead, and the connection is killed.
+ * The client will send heartbeats every 10 seconds as well. It's up to the server to decide how lenient it is in terms
+ * of missing heartbeats.
+ */
 @Suppress("MemberVisibilityCanBePrivate")
 class AxoniqConsoleRSocketClient(
     private val environmentId: String,
@@ -46,46 +60,86 @@ class AxoniqConsoleRSocketClient(
     private val encodingStrategy: RSocketPayloadEncodingStrategy,
     private val executor: ScheduledExecutorService,
     private val nodeName: String,
+    private val heartbeatTimeout: Long = 30
 ) : Lifecycle {
-    private var scheduledReconnector: ScheduledFuture<*>? = null
+    private var maintenanceTask: ScheduledFuture<*>? = null
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    private lateinit var rsocket: RSocket
-    private var connected = false
+    private var rsocket: RSocket? = null
+    private var lastSentHeartbeat = Instant.EPOCH
+    private var lastReceivedHeartbeat = Instant.now()
+    private var lastConnectionTry = Instant.EPOCH
+    private var connectionRetryCount = 0
+
+    init {
+        registrar.registerHandlerWithoutPayload(Routes.Management.HEARTBEAT) {
+            logger.debug("Received heartbeat from AxonIQ Console. Last one was: {}", lastReceivedHeartbeat)
+            lastReceivedHeartbeat = Instant.now()
+            lastReceivedHeartbeat
+        }
+    }
 
     override fun registerLifecycleHandlers(registry: Lifecycle.LifecycleRegistry) {
         registry.onStart(Phase.EXTERNAL_CONNECTIONS, this::start)
         registry.onShutdown(Phase.EXTERNAL_CONNECTIONS, this::dispose)
     }
 
+    /**
+     * Sends a message to the AxonIQ Console. If there is no connection active, does nothing silently.
+     * The connection will automatically be setup. Losing a few reports is no problem.
+     */
     fun send(route: String, payload: Any): Mono<Void> {
-        if (!connected) {
-            return Mono.empty()
-        }
         return rsocket
-            .requestResponse(encodingStrategy.encode(payload, createRoutingMetadata(route)))
-            .doOnError {
-                if (it.message?.contains("Access Denied") == true) {
-                    logger.info("Was unable to send call to AxonIQ Console since authentication was incorrect!")
-                }
-            }
-            .then()
+                ?.requestResponse(encodingStrategy.encode(payload, createRoutingMetadata(route)))
+                ?.then()
+                ?: Mono.empty()
     }
 
+    /**
+     * Starts the connection, and starts the maintenance task.
+     * The task will ensure that if heartbeats are missed the connection is killed, as well as re-setup in case
+     * the connection was lost. The task will do so with an exponential backoff with factor 2, up to a maximum of
+     * 60 seconds.
+     */
     fun start() {
-        this.scheduledReconnector = executor.scheduleWithFixedDelay({
-            if (!connected) {
-                logger.info("Reconnecting to AxonIQ Console...")
-                connect()
-            }
-        }, initialDelay, 10000, TimeUnit.MILLISECONDS)
+        this.maintenanceTask = executor.scheduleWithFixedDelay(
+                this::ensureConnectedAndAlive,
+                initialDelay,
+                1000, TimeUnit.MILLISECONDS
+        )
     }
 
-    fun connect() {
+    private fun ensureConnectedAndAlive() {
+        if (isConnected()) {
+            if (!isAlive()) {
+                logger.info("Haven't received a heartbeat for {} seconds from AxonIQ Console. Reconnecting...", ChronoUnit.SECONDS.between(lastReceivedHeartbeat, Instant.now()))
+                rsocket?.dispose()
+                rsocket = null
+            } else if(lastSentHeartbeat < Instant.now().minusSeconds(10)) {
+                logger.debug("Sending heartbeat to AxonIQ Console")
+                lastSentHeartbeat = Instant.now()
+                sendHeartbeat().subscribe()
+            }
+        }
+        if (!isConnected()) {
+            val secondsToWaitForReconnect = BACKOFF_FACTOR.pow(connectionRetryCount.toDouble()).coerceAtMost(60.0)
+            if (ChronoUnit.SECONDS.between(lastConnectionTry, Instant.now()) < secondsToWaitForReconnect) {
+                return
+            }
+            logger.info("Reconnecting to AxonIQ Console...")
+            connectSafely()
+        }
+    }
+
+    private fun connectSafely() {
         try {
             rsocket = createRSocket()
-            connected = true
+
+            // Send a heartbeat to ensure it's set up correctly. Rsocket initializes lazily, so sending a call will do it.
+            sendHeartbeat().block()
+            logger.info("Connection to AxonIQ Console set up successfully!")
         } catch (e: Exception) {
+            disposeRsocket()
             logger.info("Failed to connect to AxonIQ Console", e)
         }
     }
@@ -100,8 +154,10 @@ class AxoniqConsoleRSocketClient(
             accessToken = accessToken
         )
 
-        val setupPayload =
-            encodingStrategy.encode(setupPayloadCreator.createReport(), createSetupMetadata(authentication))
+        val setupPayload = encodingStrategy.encode(
+                setupPayloadCreator.createReport(),
+                createSetupMetadata(authentication)
+        )
         val rsocket = RSocketConnector.create()
             .metadataMimeType(WellKnownMimeType.MESSAGE_RSOCKET_COMPOSITE_METADATA.string)
             .dataMimeType(encodingStrategy.getMimeType().string)
@@ -112,6 +168,20 @@ class AxoniqConsoleRSocketClient(
             .connect(tcpClientTransport())
             .block()!!
         return rsocket
+    }
+
+    private fun sendHeartbeat(): Mono<Payload> {
+        return rsocket
+                ?.requestResponse(encodingStrategy.encode("", createRoutingMetadata(Routes.Management.HEARTBEAT)))
+                ?.doOnError {
+                    if (it.message?.contains("Access Denied") == true) {
+                        logger.info("Was unable to send call to AxonIQ Console since authentication was incorrect!")
+                    }
+                }
+                ?.doOnSuccess {
+                    logger.debug("Heartbeat successfully sent to AxonIQ Console")
+                }
+                ?: Mono.empty()
     }
 
     private fun createRoutingMetadata(route: String): CompositeByteBuf {
@@ -135,20 +205,28 @@ class AxoniqConsoleRSocketClient(
             .host(host)
             .port(port)
             .doOnDisconnected {
-                connected = false
+                disposeRsocket()
             }
         return if (secure) {
             return client.secure()
         } else client
     }
 
-    fun isConnected() = connected
+    fun isConnected() = rsocket != null
+    fun isAlive() = isConnected() && lastReceivedHeartbeat > Instant.now().minusSeconds(heartbeatTimeout)
+
+    fun disposeRsocket() {
+        rsocket?.dispose()
+        rsocket = null
+    }
 
     fun dispose() {
-        if (connected) {
-            rsocket.dispose()
-        }
-        scheduledReconnector?.cancel(true)
-        scheduledReconnector = null
+        disposeRsocket()
+        maintenanceTask?.cancel(true)
+        maintenanceTask = null
+    }
+
+    companion object {
+        private const val BACKOFF_FACTOR = 2.0
     }
 }

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/client/AxoniqConsoleRSocketClient.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/client/AxoniqConsoleRSocketClient.kt
@@ -16,6 +16,7 @@
 
 package io.axoniq.console.framework.client
 
+import io.axoniq.console.framework.api.ClientSettings
 import io.axoniq.console.framework.api.Routes
 import io.axoniq.console.framework.client.strategy.RSocketPayloadEncodingStrategy
 import io.netty.buffer.ByteBufAllocator
@@ -41,10 +42,13 @@ import kotlin.math.pow
  * The beating heart of the Console client. This class is responsible for connecting to the Console, and keeping
  * the connection alive. It will also ensure that the connection is re-established in case of a disconnect.
  *
- * The server will send heartbeats to the client every 10 seconds. Upon not receiving heartbeats for 32 seconds
- * (missing three of them) we can be sure the connection is dead, and the connection is killed.
- * The client will send heartbeats every 10 seconds as well. It's up to the server to decide how lenient it is in terms
- * of missing heartbeats.
+ * Establishing a connection works as follows:
+ * - The client will send a setup payload to the server, containing the authentication information
+ * - The client will retrieve the settings from the server, and update the [ClientSettingsService] with the new settings
+ * - The client will start sending heartbeats to the server, and will check if it receives heartbeats from the server
+ *
+ * The server is in control of these settings. Of course, the user can manipulate these as well themselves.
+ * The server should be resilient against this manipulation in the form of rate limiting.
  */
 @Suppress("MemberVisibilityCanBePrivate")
 class AxoniqConsoleRSocketClient(
@@ -58,30 +62,30 @@ class AxoniqConsoleRSocketClient(
     private val setupPayloadCreator: SetupPayloadCreator,
     private val registrar: RSocketHandlerRegistrar,
     private val encodingStrategy: RSocketPayloadEncodingStrategy,
+    private val clientSettingsService: ClientSettingsService,
     private val executor: ScheduledExecutorService,
     private val nodeName: String,
-    private val heartbeatTimeout: Long = 30
 ) : Lifecycle {
+    private val heartbeatOrchestrator = HeartbeatOrchestrator()
     private var maintenanceTask: ScheduledFuture<*>? = null
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     private var rsocket: RSocket? = null
-    private var lastSentHeartbeat = Instant.EPOCH
-    private var lastReceivedHeartbeat = Instant.now()
     private var lastConnectionTry = Instant.EPOCH
     private var connectionRetryCount = 0
 
     init {
-        registrar.registerHandlerWithoutPayload(Routes.Management.HEARTBEAT) {
-            logger.debug("Received heartbeat from AxonIQ Console. Last one was: {}", lastReceivedHeartbeat)
-            lastReceivedHeartbeat = Instant.now()
-            lastReceivedHeartbeat
+        clientSettingsService.subscribeToSettings(heartbeatOrchestrator)
+
+        // Server can send updated settings if necessary
+        registrar.registerHandlerWithPayload(Routes.Management.SETTINGS, ClientSettings::class.java) {
+            clientSettingsService.updateSettings(it)
         }
     }
 
     override fun registerLifecycleHandlers(registry: Lifecycle.LifecycleRegistry) {
         registry.onStart(Phase.EXTERNAL_CONNECTIONS, this::start)
-        registry.onShutdown(Phase.EXTERNAL_CONNECTIONS, this::dispose)
+        registry.onShutdown(Phase.EXTERNAL_CONNECTIONS, this::disposeClient)
     }
 
     /**
@@ -105,33 +109,20 @@ class AxoniqConsoleRSocketClient(
         if(this.maintenanceTask != null) {
             return
         }
-        this.lastReceivedHeartbeat = Instant.now()
         this.maintenanceTask = executor.scheduleWithFixedDelay(
-                this::ensureConnectedAndAlive,
+                this::ensureConnected,
                 initialDelay,
                 1000, TimeUnit.MILLISECONDS
         )
     }
 
-    private fun ensureConnectedAndAlive() {
-        if (isConnected()) {
-            if (!isAlive()) {
-                logger.info("Haven't received a heartbeat for {} seconds from AxonIQ Console. Reconnecting...", ChronoUnit.SECONDS.between(lastReceivedHeartbeat, Instant.now()))
-                rsocket?.dispose()
-                rsocket = null
-            } else if(lastSentHeartbeat < Instant.now().minusSeconds(10)) {
-                logger.debug("Sending heartbeat to AxonIQ Console")
-                lastSentHeartbeat = Instant.now()
-                sendHeartbeat().subscribe()
-            }
-        }
+    private fun ensureConnected() {
         if (!isConnected()) {
             val secondsToWaitForReconnect = BACKOFF_FACTOR.pow(connectionRetryCount.toDouble()).coerceAtMost(60.0)
             if (ChronoUnit.SECONDS.between(lastConnectionTry, Instant.now()) < secondsToWaitForReconnect) {
                 return
             }
             logger.info("Reconnecting to AxonIQ Console...")
-            lastReceivedHeartbeat = Instant.now()
             connectSafely()
         }
     }
@@ -139,12 +130,13 @@ class AxoniqConsoleRSocketClient(
     private fun connectSafely() {
         try {
             rsocket = createRSocket()
-
-            // Send a heartbeat to ensure it's set up correctly. Rsocket initializes lazily, so sending a call will do it.
-            sendHeartbeat().block()
-            logger.info("Connection to AxonIQ Console set up successfully!")
+            // Fetch the client settings from the server
+            val settings = retrieveSettings().block()
+                    ?: throw IllegalStateException("Could not receive the settings from AxonIQ console!")
+            clientSettingsService.updateSettings(settings)
+            logger.info("Connection to AxonIQ Console set up successfully! Settings: $settings")
         } catch (e: Exception) {
-            disposeRsocket()
+            disposeCurrentConnection()
             logger.info("Failed to connect to AxonIQ Console", e)
         }
     }
@@ -175,20 +167,6 @@ class AxoniqConsoleRSocketClient(
         return rsocket
     }
 
-    private fun sendHeartbeat(): Mono<Payload> {
-        return rsocket
-                ?.requestResponse(encodingStrategy.encode("", createRoutingMetadata(Routes.Management.HEARTBEAT)))
-                ?.doOnError {
-                    if (it.message?.contains("Access Denied") == true) {
-                        logger.info("Was unable to send call to AxonIQ Console since authentication was incorrect!")
-                    }
-                }
-                ?.doOnSuccess {
-                    logger.debug("Heartbeat successfully sent to AxonIQ Console")
-                }
-                ?: Mono.empty()
-    }
-
     private fun createRoutingMetadata(route: String): CompositeByteBuf {
         val metadata: CompositeByteBuf = ByteBufAllocator.DEFAULT.compositeBuffer()
         metadata.addRouteMetadata(route)
@@ -210,7 +188,7 @@ class AxoniqConsoleRSocketClient(
             .host(host)
             .port(port)
             .doOnDisconnected {
-                disposeRsocket()
+                disposeCurrentConnection()
             }
         return if (secure) {
             return client.secure()
@@ -218,20 +196,91 @@ class AxoniqConsoleRSocketClient(
     }
 
     fun isConnected() = rsocket != null
-    fun isAlive() = isConnected() && lastReceivedHeartbeat > Instant.now().minusSeconds(heartbeatTimeout)
 
-    fun disposeRsocket() {
+    fun disposeCurrentConnection() {
         rsocket?.dispose()
         rsocket = null
+        clientSettingsService.clearSettings()
     }
 
-    fun dispose() {
-        disposeRsocket()
+    fun disposeClient() {
+        disposeCurrentConnection()
         maintenanceTask?.cancel(true)
         maintenanceTask = null
     }
 
     companion object {
         private const val BACKOFF_FACTOR = 2.0
+    }
+
+    private inner class HeartbeatOrchestrator : ClientSettingsObserver {
+        private var heartbeatSendTask: ScheduledFuture<*>? = null
+        private var heartbeatCheckTask: ScheduledFuture<*>? = null
+        private var lastReceivedHeartbeat = Instant.now()
+
+        init {
+            registrar.registerHandlerWithoutPayload(Routes.Management.HEARTBEAT) {
+                logger.debug("Received heartbeat from AxonIQ Console. Last one was: {}", lastReceivedHeartbeat)
+                lastReceivedHeartbeat = Instant.now()
+                lastReceivedHeartbeat
+            }
+        }
+
+        override fun onConnectedWithSettings(settings: ClientSettings) {
+            lastReceivedHeartbeat = Instant.now()
+            this.heartbeatSendTask = executor.scheduleWithFixedDelay(
+                    { sendHeartbeat().subscribe() },
+                    0,
+                    settings.heartbeatInterval,
+                    TimeUnit.MILLISECONDS
+            )
+
+            this.heartbeatCheckTask = executor.scheduleWithFixedDelay(
+                    { checkHeartbeats(settings.heartbeatTimeout) },
+                    0,
+                    1000,
+                    TimeUnit.MILLISECONDS
+            )
+
+        }
+
+        override fun onDisconnected() {
+            logger.info("Disconnected, stopping heartbeat tasks")
+            this.heartbeatSendTask?.cancel(true)
+            this.heartbeatCheckTask?.cancel(true)
+        }
+
+
+        private fun checkHeartbeats(heartbeatTimeout: Long) {
+            if (lastReceivedHeartbeat < Instant.now().minusMillis(heartbeatTimeout)) {
+                logger.info("Haven't received a heartbeat for {} seconds from AxonIQ Console. Reconnecting...", ChronoUnit.SECONDS.between(lastReceivedHeartbeat, Instant.now()))
+                disposeCurrentConnection()
+            }
+        }
+
+        private fun sendHeartbeat(): Mono<Payload> {
+            return rsocket
+                    ?.requestResponse(encodingStrategy.encode("", createRoutingMetadata(Routes.Management.HEARTBEAT)))
+                    ?.doOnSuccess {
+                        logger.debug("Heartbeat successfully sent to AxonIQ Console")
+                    }
+                    ?: Mono.empty()
+        }
+    }
+
+    private fun retrieveSettings(): Mono<ClientSettings> {
+        return rsocket!!
+                .requestResponse(encodingStrategy.encode("", createRoutingMetadata(Routes.Management.SETTINGS)))
+                .map {
+                    encodingStrategy.decode(it, ClientSettings::class.java)
+                }
+                .doOnError {
+                    if (it.message?.contains("Access Denied") == true) {
+                        logger.info("Was unable to send call to AxonIQ Console since authentication was incorrect!")
+                    }
+                }
+                .doOnSuccess {
+                    logger.debug("Heartbeat successfully sent to AxonIQ Console")
+                }
     }
 }

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/client/AxoniqConsoleRSocketClient.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/client/AxoniqConsoleRSocketClient.kt
@@ -102,6 +102,9 @@ class AxoniqConsoleRSocketClient(
      * 60 seconds.
      */
     fun start() {
+        if(this.maintenanceTask != null) {
+            return
+        }
         this.maintenanceTask = executor.scheduleWithFixedDelay(
                 this::ensureConnectedAndAlive,
                 initialDelay,

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/client/AxoniqConsoleRSocketClient.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/client/AxoniqConsoleRSocketClient.kt
@@ -122,7 +122,7 @@ class AxoniqConsoleRSocketClient(
             if (ChronoUnit.SECONDS.between(lastConnectionTry, Instant.now()) < secondsToWaitForReconnect) {
                 return
             }
-            logger.info("Reconnecting to AxonIQ Console...")
+            logger.info("Connecting to AxonIQ Console...")
             connectSafely()
         }
     }
@@ -278,9 +278,6 @@ class AxoniqConsoleRSocketClient(
                     if (it.message?.contains("Access Denied") == true) {
                         logger.info("Was unable to send call to AxonIQ Console since authentication was incorrect!")
                     }
-                }
-                .doOnSuccess {
-                    logger.debug("Heartbeat successfully sent to AxonIQ Console")
                 }
     }
 }

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/client/AxoniqConsoleRSocketClient.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/client/AxoniqConsoleRSocketClient.kt
@@ -105,6 +105,7 @@ class AxoniqConsoleRSocketClient(
         if(this.maintenanceTask != null) {
             return
         }
+        this.lastReceivedHeartbeat = Instant.now()
         this.maintenanceTask = executor.scheduleWithFixedDelay(
                 this::ensureConnectedAndAlive,
                 initialDelay,
@@ -130,6 +131,7 @@ class AxoniqConsoleRSocketClient(
                 return
             }
             logger.info("Reconnecting to AxonIQ Console...")
+            lastReceivedHeartbeat = Instant.now()
             connectSafely()
         }
     }

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/client/ClientSettingsObserver.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/client/ClientSettingsObserver.kt
@@ -1,0 +1,22 @@
+package io.axoniq.console.framework.client
+
+import io.axoniq.console.framework.api.ClientSettings
+
+/**
+ * Observes the established connection and the settings provided by the server.
+ * The [onDisconnected] method is called when the connection is lost, or just before new settings
+ * are being updated to provide cleanup. The [onConnectedWithSettings] method is called when the connection is
+ * established or the settings are updated
+ */
+interface ClientSettingsObserver {
+    /**
+     * Called when the connection is established or the settings are updated.
+     * @param settings the settings provided by the server
+     */
+    fun onConnectedWithSettings(settings: ClientSettings)
+
+    /**
+     * Called when the connection is lost, or just before new settings are being updated to provide cleanup.
+     */
+    fun onDisconnected()
+}

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/client/ClientSettingsService.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/client/ClientSettingsService.kt
@@ -1,0 +1,32 @@
+package io.axoniq.console.framework.client
+
+import io.axoniq.console.framework.api.ClientSettings
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Service that holds the client settings. See [ClientSettingsObserver] for more information.
+ */
+class ClientSettingsService {
+    private val observers = CopyOnWriteArrayList<ClientSettingsObserver>()
+    private var settings: ClientSettings? = null
+
+    fun clearSettings() {
+        if(settings != null) {
+            settings = null
+            observers.forEach { it.onDisconnected() }
+        }
+    }
+
+    fun subscribeToSettings(observer: ClientSettingsObserver) {
+        this.observers.add(observer)
+        if(settings != null) {
+            observer.onConnectedWithSettings(settings!!)
+        }
+    }
+
+    fun updateSettings(settings: ClientSettings) {
+        clearSettings()
+        this.settings = settings
+        observers.forEach { it.onConnectedWithSettings(settings) }
+    }
+}

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/client/SetupPayloadCreator.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/client/SetupPayloadCreator.kt
@@ -66,7 +66,8 @@ class SetupPayloadCreator(
                 )
             },
             versions = versionInformation(),
-            upcasters = upcasters()
+            upcasters = upcasters(),
+            features = SupportedFeatures(true)
         )
     }
 

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/client/SetupPayloadCreator.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/client/SetupPayloadCreator.kt
@@ -67,7 +67,9 @@ class SetupPayloadCreator(
             },
             versions = versionInformation(),
             upcasters = upcasters(),
-            features = SupportedFeatures(true)
+            features = SupportedFeatures(
+                    heartbeat = true
+            )
         )
     }
 

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/client/SetupPayloadCreator.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/client/SetupPayloadCreator.kt
@@ -51,7 +51,7 @@ class SetupPayloadCreator(
             processors = processors.map {
                 val processor =
                     eventProcessingConfiguration.eventProcessor(it, StreamingEventProcessor::class.java).get()
-                io.axoniq.console.framework.api.ProcessorInformation(
+                ProcessorInformation(
                     name = it,
                     supportsReset = processor.supportsReset(),
                     batchSize = processor.getBatchSize(),

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/HandlerMetricsRegistry.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/HandlerMetricsRegistry.kt
@@ -16,25 +16,29 @@
 
 package io.axoniq.console.framework.messaging
 
+import io.axoniq.console.framework.api.ClientSettings
 import io.axoniq.console.framework.api.metrics.*
 import io.axoniq.console.framework.client.AxoniqConsoleRSocketClient
+import io.axoniq.console.framework.client.ClientSettingsObserver
+import io.axoniq.console.framework.client.ClientSettingsService
 import io.axoniq.console.framework.computeIfAbsentWithRetry
 import io.micrometer.core.instrument.Timer
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import org.axonframework.lifecycle.Lifecycle
-import org.axonframework.lifecycle.Phase
-import org.slf4j.LoggerFactory
+import mu.KotlinLogging
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 
 class HandlerMetricsRegistry(
     private val axoniqConsoleRSocketClient: AxoniqConsoleRSocketClient,
+    private val clientSettingsService: ClientSettingsService,
     private val executor: ScheduledExecutorService,
     private val componentName: String,
-) : Lifecycle {
-    private val logger = LoggerFactory.getLogger(this::class.java)
+) : ClientSettingsObserver {
+    private val logger = KotlinLogging.logger { }
+    private var reportTask: ScheduledFuture<*>? = null
     private val meterRegistry = SimpleMeterRegistry()
 
     private val dispatches: MutableMap<DispatcherStatisticIdentifier, RollingCountMeasure> = ConcurrentHashMap()
@@ -43,27 +47,19 @@ class HandlerMetricsRegistry(
 
     private val noHandlerIdentifier = HandlerStatisticsMetricIdentifier(HandlerType.Origin, "application", MessageIdentifier("Dispatcher", componentName))
 
-    override fun registerLifecycleHandlers(lifecycle: Lifecycle.LifecycleRegistry) {
-        lifecycle.onStart(Phase.INSTRUCTION_COMPONENTS, this::start)
-    }
-
-    companion object {
-        private var instance: HandlerMetricsRegistry? = null
-        private var started: Boolean = false
-
-        /**
-         * Gets the current instance
-         */
-        fun getInstance() = instance
-    }
-
-    fun start() {
-        if (instance != null) {
-            logger.debug("HandlerMetricRegistry instance already started. Skipping new.")
-            return
+    init {
+        if(instance != null) {
+            logger.warn("HandlerMetricsRegistry already initialized. The new one will be the active.")
+            // Clear it to be sure. This is a situation that should not happen though.
+            instance?.onDisconnected()
         }
         instance = this
-        executor.scheduleAtFixedRate({
+        clientSettingsService.subscribeToSettings(this)
+    }
+
+    override fun onConnectedWithSettings(settings: ClientSettings) {
+        logger.info { "Sending handler information every ${settings.handlerReportInterval}ms to AxonIQ console" }
+        this.reportTask = executor.scheduleAtFixedRate({
             try {
                 val stats = getStats()
                 logger.debug("Sending metrics: {}", stats)
@@ -71,8 +67,21 @@ class HandlerMetricsRegistry(
             } catch (e: Exception) {
                 logger.warn("No metrics could be reported to AxonIQ Console: {}", e.message)
             }
-        }, 10, 10, TimeUnit.SECONDS)
-        started = true
+        }, 0, settings.handlerReportInterval, TimeUnit.MILLISECONDS)
+    }
+
+    override fun onDisconnected() {
+        this.reportTask?.cancel(true)
+        this.reportTask = null
+    }
+
+    companion object {
+        private var instance: HandlerMetricsRegistry? = null
+
+        /**
+         * Gets the current instance
+         */
+        fun getInstance() = instance
     }
 
     private fun getStats(): StatisticReport {


### PR DESCRIPTION
Fixes #32. Extends the routes to include a bi-directional heartbeat route. Sending and receiving heartbeats should happen every 10 seconds. If heartbeats are missed for 30 seconds, the connection is set up from scratch again.

The server knows that we support heartbeats through the SetupPayload's feature flags. The API default to false for backwards compatibility.