### PR TITLE
Ignore credentials if they are wrongly formatted

### DIFF
--- a/console-framework-client-spring-boot-starter/src/main/java/io/axoniq/console/framework/starter/AxoniqConsoleAutoConfiguration.kt
+++ b/console-framework-client-spring-boot-starter/src/main/java/io/axoniq/console/framework/starter/AxoniqConsoleAutoConfiguration.kt
@@ -51,6 +51,10 @@ class AxoniqConsoleAutoConfiguration {
             logger.warn("No credentials were provided for the connection to AxonIQ Console. Please provide them as instructed through the 'axoniq.console.credentials' property.")
             return ConfigurerModule { }
         }
+        if (!credentials.contains(":")) {
+            logger.warn("The credentials for the connection to AxonIQ Console don't have the right format. Please provide them as instructed through the 'axoniq.console.credentials' property.")
+            return ConfigurerModule { }
+        }
         val applicationName = (properties.applicationName?.trim()?.ifEmpty { null })
             ?: (applicationContext.applicationName.trim().ifEmpty { null })
             ?: (applicationContext.id?.removeSuffix("-1"))


### PR DESCRIPTION
When credentials are provided, but are represented in the wrong format (e.g. token only, no environment ID), then the connector fails and prevents application startup.

This commit adds a format check and disables the client when wrongly formatted credentials are found.