### PR TITLE
Add a new dlq mode that will not share events, and only the whitelisted diagnostic data.

### DIFF
--- a/console-framework-client-spring-boot-starter/src/main/java/io/axoniq/console/framework/starter/AxoniqConsoleAutoConfiguration.kt
+++ b/console-framework-client-spring-boot-starter/src/main/java/io/axoniq/console/framework/starter/AxoniqConsoleAutoConfiguration.kt
@@ -43,8 +43,8 @@ class AxoniqConsoleAutoConfiguration {
     @Bean
     @ConditionalOnProperty("axoniq.console.credentials", matchIfMissing = false)
     fun axoniqConsoleConfigurerModule(
-        properties: AxoniqConsoleSpringProperties,
-        applicationContext: ApplicationContext
+            properties: AxoniqConsoleSpringProperties,
+            applicationContext: ApplicationContext
     ): ConfigurerModule {
         val credentials = properties.credentials
         if (credentials == null) {
@@ -56,28 +56,29 @@ class AxoniqConsoleAutoConfiguration {
             return ConfigurerModule { }
         }
         val applicationName = (properties.applicationName?.trim()?.ifEmpty { null })
-            ?: (applicationContext.applicationName.trim().ifEmpty { null })
-            ?: (applicationContext.id?.removeSuffix("-1"))
+                ?: (applicationContext.applicationName.trim().ifEmpty { null })
+                ?: (applicationContext.id?.removeSuffix("-1"))
         if (applicationName == null) {
             logger.warn("Was unable to determine your application's name. Please provide it through the 'axoniq.console.application-name' property.")
             return ConfigurerModule { }
         }
         val (environmentId, accessToken) = credentials.split(":")
         logger.info(
-            "Setting up client for AxonIQ Console environment {}. This application will be registered as {}",
-            environmentId,
-            applicationName
+                "Setting up client for AxonIQ Console environment {}. This application will be registered as {}",
+                environmentId,
+                applicationName
         )
-        return AxoniqConsoleConfigurerModule
-            .builder(environmentId, accessToken, applicationName)
-            .port(properties.port)
-            .host(properties.host)
-            .dlqMode(properties.dlqMode)
-            .secure(properties.isSecure)
-            .initialDelay(properties.initialDelay)
-            .disableSpanFactoryInConfiguration()
-            .managementMaxThreadPoolSize(properties.maxConcurrentManagementTasks)
-            .build()
+        val builder = AxoniqConsoleConfigurerModule
+                .builder(environmentId, accessToken, applicationName)
+                .port(properties.port)
+                .host(properties.host)
+                .dlqMode(properties.dlqMode)
+                .secure(properties.isSecure)
+                .initialDelay(properties.initialDelay)
+                .disableSpanFactoryInConfiguration()
+                .managementMaxThreadPoolSize(properties.maxConcurrentManagementTasks)
+        properties.dlqDiagnosticsWhitelist.forEach { builder.addDlqDiagnosticsWhitelistKey(it) }
+        return builder.build()
     }
 
     @Bean
@@ -100,10 +101,10 @@ class AxoniqConsoleAutoConfiguration {
                 return spanFactory
             }
             return MultiSpanFactory(
-                listOf(
-                    spanFactory,
-                    bean
-                )
+                    listOf(
+                            spanFactory,
+                            bean
+                    )
             )
         }
     }

--- a/console-framework-client-spring-boot-starter/src/main/java/io/axoniq/console/framework/starter/AxoniqConsoleAutoConfiguration.kt
+++ b/console-framework-client-spring-boot-starter/src/main/java/io/axoniq/console/framework/starter/AxoniqConsoleAutoConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023. AxonIQ B.V.
+ * Copyright (c) 2022-2024. AxonIQ B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/console-framework-client-spring-boot-starter/src/main/java/io/axoniq/console/framework/starter/AxoniqConsoleSpringProperties.java
+++ b/console-framework-client-spring-boot-starter/src/main/java/io/axoniq/console/framework/starter/AxoniqConsoleSpringProperties.java
@@ -3,6 +3,9 @@ package io.axoniq.console.framework.starter;
 import io.axoniq.console.framework.AxoniqConsoleDlqMode;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @ConfigurationProperties(prefix = "axoniq.console")
 public class AxoniqConsoleSpringProperties {
     /**
@@ -28,6 +31,11 @@ public class AxoniqConsoleSpringProperties {
      * DLQ visibility.
      */
     private AxoniqConsoleDlqMode dlqMode = AxoniqConsoleDlqMode.FULL;
+    /**
+     * The list which can be used in combination with setting the {@code dlqMode} to
+     * {@link AxoniqConsoleDlqMode#LIMITED}. In that mode it will filter the diagnostics based on this list.
+     */
+    private List<String> dlqDiagnosticsWhitelist = new ArrayList<>();
     /**
      * Whether the connection should use SSL/TLs. Defaults to {@code true}.
      */
@@ -81,6 +89,14 @@ public class AxoniqConsoleSpringProperties {
 
     public void setDlqMode(AxoniqConsoleDlqMode dlqMode) {
         this.dlqMode = dlqMode;
+    }
+
+    public List<String> getDlqDiagnosticsWhitelist() {
+        return dlqDiagnosticsWhitelist;
+    }
+
+    public void setDlqDiagnosticsWhitelist(List<String> dlqDiagnosticsWhitelist) {
+        this.dlqDiagnosticsWhitelist = dlqDiagnosticsWhitelist;
     }
 
     public boolean isSecure() {

--- a/console-framework-client-spring-boot-starter/src/main/java/io/axoniq/console/framework/starter/AxoniqConsoleSpringProperties.java
+++ b/console-framework-client-spring-boot-starter/src/main/java/io/axoniq/console/framework/starter/AxoniqConsoleSpringProperties.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2022-2024. AxonIQ B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.axoniq.console.framework.starter;
 
 import io.axoniq.console.framework.AxoniqConsoleDlqMode;
@@ -8,6 +24,7 @@ import java.util.List;
 
 @ConfigurationProperties(prefix = "axoniq.console")
 public class AxoniqConsoleSpringProperties {
+
     /**
      * The host to connect to. Defaults to {@code framework.console.axoniq.io}.
      */
@@ -26,14 +43,15 @@ public class AxoniqConsoleSpringProperties {
      */
     private String applicationName = null;
     /**
-     * The mode of DLQ operations. Defaults to {@code FULL}, which can return sensitive information to the UI.
-     * If this concerns you, consider {@code MASKED} to mask potentially sensitive data, or {@code NONE} to disable
-     * DLQ visibility.
+     * The mode of DLQ operations. Defaults to {@code FULL}, which can return sensitive information to the UI. If this
+     * concerns you, consider {@code MASKED} to mask potentially sensitive data, or {@code NONE} to disable DLQ
+     * visibility.
      */
     private AxoniqConsoleDlqMode dlqMode = AxoniqConsoleDlqMode.FULL;
     /**
      * The list which can be used in combination with setting the {@code dlqMode} to
-     * {@link AxoniqConsoleDlqMode#LIMITED}. In that mode it will filter the diagnostics based on this list.
+     * {@link AxoniqConsoleDlqMode#LIMITED}. In that mode it will filter the diagnostics based on this list. It will use
+     * the list as the keys to filter on.
      */
     private List<String> dlqDiagnosticsWhitelist = new ArrayList<>();
     /**
@@ -46,8 +64,8 @@ public class AxoniqConsoleSpringProperties {
     private Long initialDelay = 0L;
 
     /**
-     * The maximum number of concurrent management tasks. Defaults to {@code 5}.
-     * Management tasks are tasks executed at the request of the user, such as processing DLQ messages.
+     * The maximum number of concurrent management tasks. Defaults to {@code 5}. Management tasks are tasks executed at
+     * the request of the user, such as processing DLQ messages.
      */
     private int maxConcurrentManagementTasks = 5;
 

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/AxoniqConsoleConfigurerModule.java
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/AxoniqConsoleConfigurerModule.java
@@ -314,7 +314,7 @@ public class AxoniqConsoleConfigurerModule implements ConfigurerModule {
         }
 
         /**
-         * Adding a key to the whitelist. Will only be used in combination with setting the {@code dlqMode} to
+         * Adding a key to the diagnostics whitelist. Will only be used in combination with setting the {@code dlqMode} to
          * {@link AxoniqConsoleDlqMode#LIMITED}. It will filter the diagnostics, and only show the ones included in the
          * whitelist.
          *

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/AxoniqConsoleConfigurerModule.java
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/AxoniqConsoleConfigurerModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023. AxonIQ B.V.
+ * Copyright (c) 2022-2024. AxonIQ B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/AxoniqConsoleDlqMode.java
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/AxoniqConsoleDlqMode.java
@@ -6,6 +6,11 @@ public enum AxoniqConsoleDlqMode {
      */
     FULL,
     /**
+     * In this mode the event payload will never send over the wire. From the diagnostics only the entries which are
+     * included in the whitelist will be sent over the wire. The sequence identifier will not be hashed and send as-is.
+     */
+    LIMITED,
+    /**
      * Limited data of messages in the DLQ are available in the API. Sensitive information is masked.
      * The sequence identifier is hashed through SHA256 to still enable processing actions.
      */

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/AxoniqConsoleDlqMode.java
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/AxoniqConsoleDlqMode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2022-2024. AxonIQ B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.axoniq.console.framework;
 
 public enum AxoniqConsoleDlqMode {

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/DeadLetterManager.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/DeadLetterManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023. AxonIQ B.V.
+ * Copyright (c) 2022-2024. AxonIQ B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This will provide an usable middle ground between masked and full. Where users are sure none of the event payload data is exposed, and only the part of the diagnostics which is in the whitelist.
