### PR TITLE
Second generation event processors

### DIFF
--- a/console-framework-client-api/pom.xml
+++ b/console-framework-client-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.axoniq.console</groupId>
         <artifactId>console-framework-client-parent</artifactId>
-        <version>1.5.2-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/eventProcessorApi.kt
+++ b/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/eventProcessorApi.kt
@@ -19,7 +19,7 @@ package io.axoniq.console.framework.api
 import java.time.Instant
 
 data class ProcessorStatusReport(
-    val processors: List<ProcessorStatus>
+        val processors: List<ProcessorStatus>
 )
 
 enum class ProcessorMode {
@@ -30,38 +30,40 @@ enum class ProcessorMode {
 }
 
 data class ProcessorStatus(
-    val name: String,
-    val processingGroups: List<ProcessingGroupStatus>,
-    val tokenStoreIdentifier: String,
-    val mode: ProcessorMode,
-    val started: Boolean,
-    val error: Boolean,
-    val segmentCapacity: Int,
-    val activeSegments: Int,
-    val segments: List<SegmentStatus>,
+        val name: String,
+        val processingGroups: List<ProcessingGroupStatus>,
+        val tokenStoreIdentifier: String,
+        val mode: ProcessorMode,
+        val started: Boolean,
+        val error: Boolean,
+        val segmentCapacity: Int,
+        val activeSegments: Int,
+        val segments: List<SegmentStatus>,
 )
 
 data class ProcessingGroupStatus(
-    val name: String,
-    val dlqSize: Long?,
+        val name: String,
+        val dlqSize: Long?,
 )
 
 data class SegmentStatus(
-    val segment: Int,
-    val mergeableSegment: Int,
-    val mask: Int = -1,
-    val oneOf: Int,
-    val caughtUp: Boolean,
-    val error: Boolean,
-    val errorType: String?,
-    val errorMessage: String?,
-    val ingestLatency: Double?,
-    val commitLatency: Double?,
+        val segment: Int,
+        val mergeableSegment: Int,
+        val mask: Int = -1,
+        val oneOf: Int,
+        val caughtUp: Boolean,
+        val error: Boolean,
+        val errorType: String?,
+        val errorMessage: String?,
+        val ingestLatency: Double?,
+        val commitLatency: Double?,
+        val position: Long? = -1,
+        val resetPosition: Long? = -1,
 )
 
 data class ProcessorSegmentId(
-    val processorName: String,
-    val segmentId: Int
+        val processorName: String,
+        val segmentId: Int
 )
 
 enum class ResetDecisions {
@@ -69,18 +71,18 @@ enum class ResetDecisions {
 }
 
 data class ResetDecision(
-    val processorName: String,
-    val decision: ResetDecisions,
-    val from: Instant? = null
+        val processorName: String,
+        val decision: ResetDecisions,
+        val from: Instant? = null
 )
 
 data class SegmentOverview(
-    val segments: List<SegmentDetails>
+        val segments: List<SegmentDetails>
 )
 
 data class SegmentDetails(
 
-    val segment: Int,
-    val mergeableSegment: Int,
-    val mask: Int,
+        val segment: Int,
+        val mergeableSegment: Int,
+        val mask: Int,
 )

--- a/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/eventProcessorApi.kt
+++ b/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/eventProcessorApi.kt
@@ -25,6 +25,7 @@ data class ProcessorStatusReport(
 enum class ProcessorMode {
     POOLED,
     TRACKING,
+    SUBSCRIBING,
     UNKNOWN,
 }
 

--- a/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/metrics/HandlerType.kt
+++ b/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/metrics/HandlerType.kt
@@ -16,9 +16,9 @@
 
 package io.axoniq.console.framework.api.metrics
 
-enum class HandlerType {
-    Origin,
-    EventProcessor,
-    Aggregate,
-    Message,
+enum class HandlerType(val shortIdentifier: String) {
+    Origin("o"),
+    EventProcessor("ep"),
+    Aggregate("ag"),
+    Message("m"),
 }

--- a/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/metrics/Metric.kt
+++ b/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/metrics/Metric.kt
@@ -16,14 +16,14 @@
 
 package io.axoniq.console.framework.api.metrics
 
-import io.axoniq.console.framework.api.metrics.MetricTargetType.*
+import io.axoniq.console.framework.api.metrics.MetricTargetType.AGGREGATE
+import io.axoniq.console.framework.api.metrics.MetricTargetType.HANDLER
 
 
 interface Metric {
     val type: MetricType
     val identifier: String
     val description: String
-    val breakDownMetrics: List<Metric>
     val targetTypes: List<MetricTargetType>
 
 
@@ -31,51 +31,58 @@ interface Metric {
         get() = "${type.metricPrefix}_${identifier}"
 }
 
+data class ChildHandlerMetric(
+        val handler: HandlerStatisticsMetricIdentifier
+) : Metric {
+    override val type: MetricType = MetricType.TIMER
+    override val description: String = "Time it took for the event handler to process an event as subscriber"
+    override val identifier: String = "${handler.type.shortIdentifier}_\"${handler.component}\"_\"${handler.message.type}\"_\"${handler.message.name}\""
+    override val targetTypes: List<MetricTargetType> = listOf(HANDLER)
+
+}
+
 data class UserHandlerInterceptorMetric(
-    override val type: MetricType = MetricType.TIMER,
-    override val identifier: String,
-    override val description: String = "User defined metric",
-    override val breakDownMetrics: List<Metric> = emptyList(),
-    override val targetTypes: List<MetricTargetType> = listOf(HANDLER, AGGREGATE),
+        override val type: MetricType = MetricType.TIMER,
+        override val identifier: String,
+        override val description: String = "User defined metric",
+        override val targetTypes: List<MetricTargetType> = listOf(HANDLER, AGGREGATE),
 ) : Metric
 
 enum class PreconfiguredMetric(
-    override val type: MetricType,
-    override val identifier: String,
-    override val description: String,
-    override val breakDownMetrics: List<Metric> = listOf(),
-    override val targetTypes: List<MetricTargetType>,
+        override val type: MetricType,
+        override val identifier: String,
+        override val description: String,
+        override val targetTypes: List<MetricTargetType>,
 ) : Metric {
     MESSAGE_HANDLER_TIME(
-        type = MetricType.TIMER,
-        identifier = "handler",
-        description = "Time it took for the actual user-made handler function to be invoked",
-        targetTypes = listOf(AGGREGATE, HANDLER),
+            type = MetricType.TIMER,
+            identifier = "handler",
+            description = "Time it took for the actual user-made handler function to be invoked",
+            targetTypes = listOf(AGGREGATE, HANDLER),
     ),
     AGGREGATE_LOCK_TIME(
-        type = MetricType.TIMER,
-        identifier = "aggregate_lock",
-        description = "Time it took for a command to acquire a lock for the aggregate identifier",
-        targetTypes = listOf(AGGREGATE, HANDLER),
+            type = MetricType.TIMER,
+            identifier = "aggregate_lock",
+            description = "Time it took for a command to acquire a lock for the aggregate identifier",
+            targetTypes = listOf(AGGREGATE, HANDLER),
     ),
     AGGREGATE_LOAD_TIME(
-        type = MetricType.TIMER,
-        identifier = "aggregate_load",
-        description = "Time it took for a command to load the target aggregate",
-        targetTypes = listOf(AGGREGATE, HANDLER),
-        breakDownMetrics = listOf(AGGREGATE_LOCK_TIME)
+            type = MetricType.TIMER,
+            identifier = "aggregate_load",
+            description = "Time it took for a command to load the target aggregate",
+            targetTypes = listOf(AGGREGATE, HANDLER),
     ),
     EVENT_COMMIT_TIME(
-        type = MetricType.TIMER,
-        identifier = "event_commit",
-        description = "Time it took to commit events to the event store",
-        targetTypes = listOf(AGGREGATE, HANDLER)
+            type = MetricType.TIMER,
+            identifier = "event_commit",
+            description = "Time it took to commit events to the event store",
+            targetTypes = listOf(AGGREGATE, HANDLER)
     ),
     AGGREGATE_EVENTS_SIZE(
-        type = MetricType.COUNTER,
-        identifier = "agg_events_size",
-        description = "Amount of events loaded during aggregate initialization",
-        targetTypes = listOf(AGGREGATE)
+            type = MetricType.COUNTER,
+            identifier = "agg_events_size",
+            description = "Amount of events loaded during aggregate initialization",
+            targetTypes = listOf(AGGREGATE)
     )
 
     ;

--- a/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/metrics/Metric.kt
+++ b/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/metrics/Metric.kt
@@ -64,13 +64,13 @@ enum class PreconfiguredMetric(
             type = MetricType.TIMER,
             identifier = "aggregate_lock",
             description = "Time it took for a command to acquire a lock for the aggregate identifier",
-            targetTypes = listOf(AGGREGATE, HANDLER),
+            targetTypes = listOf(AGGREGATE),
     ),
     AGGREGATE_LOAD_TIME(
             type = MetricType.TIMER,
             identifier = "aggregate_load",
             description = "Time it took for a command to load the target aggregate",
-            targetTypes = listOf(AGGREGATE, HANDLER),
+            targetTypes = listOf(AGGREGATE),
     ),
     EVENT_COMMIT_TIME(
             type = MetricType.TIMER,

--- a/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/metrics/Metric.kt
+++ b/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/metrics/Metric.kt
@@ -64,13 +64,13 @@ enum class PreconfiguredMetric(
             type = MetricType.TIMER,
             identifier = "aggregate_lock",
             description = "Time it took for a command to acquire a lock for the aggregate identifier",
-            targetTypes = listOf(AGGREGATE),
+            targetTypes = listOf(AGGREGATE, HANDLER),
     ),
     AGGREGATE_LOAD_TIME(
             type = MetricType.TIMER,
             identifier = "aggregate_load",
             description = "Time it took for a command to load the target aggregate",
-            targetTypes = listOf(AGGREGATE),
+            targetTypes = listOf(AGGREGATE, HANDLER),
     ),
     EVENT_COMMIT_TIME(
             type = MetricType.TIMER,

--- a/console-framework-client-spring-boot-starter/pom.xml
+++ b/console-framework-client-spring-boot-starter/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.axoniq.console</groupId>
         <artifactId>console-framework-client-parent</artifactId>
-        <version>1.5.2-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/console-framework-client/pom.xml
+++ b/console-framework-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.axoniq.console</groupId>
         <artifactId>console-framework-client-parent</artifactId>
-        <version>1.5.2-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/client/SetupPayloadCreator.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/client/SetupPayloadCreator.kt
@@ -23,7 +23,9 @@ import org.axonframework.common.ReflectionUtils
 import org.axonframework.config.Configuration
 import org.axonframework.config.EventProcessingModule
 import org.axonframework.eventhandling.*
+import org.axonframework.eventhandling.pooled.PooledStreamingEventProcessor
 import org.axonframework.eventhandling.tokenstore.TokenStore
+import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore
 import org.axonframework.eventsourcing.eventstore.EventStore
 import org.axonframework.messaging.StreamableMessageSource
 import org.axonframework.queryhandling.QueryBus
@@ -38,37 +40,132 @@ class SetupPayloadCreator(
     private val eventProcessingConfiguration = configuration.eventProcessingConfiguration() as EventProcessingModule
 
     fun createReport(): SetupPayload {
-        val processors = eventProcessingConfiguration.eventProcessors()
-                .filter { it.value is StreamingEventProcessor }
-                .map { entry ->
-                    entry.key
-                }
+        val processors = eventProcessingConfiguration.eventProcessors().keys
         return SetupPayload(
                 commandBus = commandBusInformation(),
                 queryBus = queryBusInformation(),
                 eventStore = eventBusInformation(),
-                processors = processors.map {
-                    val processor =
-                            eventProcessingConfiguration.eventProcessor(it, StreamingEventProcessor::class.java).get()
-                    ProcessorInformation(
-                            name = it,
-                            supportsReset = processor.supportsReset(),
-                            batchSize = processor.getBatchSize(),
-                            messageSourceType = processor.getMessageSource(),
-                            tokenClaimInterval = processor.getTokenClaimInterval(),
-                            tokenStoreClaimTimeout = processor.getStoreTokenClaimTimeout(),
-                            errorHandler = eventProcessingConfiguration.errorHandler(it)::class.java.name,
-                            invocationErrorHandler = eventProcessingConfiguration.listenerInvocationErrorHandler(it)::class.java.name,
-                            interceptors = processor.getInterceptors("interceptors"),
-                            tokenStoreType = processor.getStoreTokenStoreType(),
-                            contexts = processor.contexts()
-                    )
+                processors = processors.mapNotNull {
+                    toProcessor(it)
                 },
                 versions = versionInformation(),
                 upcasters = upcasters(),
                 features = SupportedFeatures(
                         heartbeat = true
                 )
+        )
+    }
+
+    private fun toProcessor(name: String): EventProcessorInformation? {
+        val processor = eventProcessingConfiguration.eventProcessor(name, EventProcessor::class.java).orElse(null)
+        return when (processor) {
+            is PooledStreamingEventProcessor -> toPooledStreamingProcessorInformation(processor)
+            is TrackingEventProcessor -> toTrackingProcessorInformation(processor)
+            is SubscribingEventProcessor -> toSubscribingProcessorInformation(processor)
+            else -> null
+        }
+    }
+
+    private fun toSubscribingProcessorInformation(processor: SubscribingEventProcessor): EventProcessorInformation {
+        return EventProcessorInformation(
+                name = processor.name,
+                processorType = ProcessorType.SUBSCRIBING,
+                commonProcessorInformation = commonProcessorInformation(processor),
+                subscribingProcessorInformation = SubscribingProcessorInformation(
+                        processingStrategy = processor.getPropertyType("processingStrategy")
+                )
+        )
+    }
+
+    private fun commonProcessorInformation(processor: EventProcessor) =
+            CommonProcessorInformation(
+                    messageSource = toMessageSource(processor.getPropertyValue("messageSource")),
+                    errorHandler = eventProcessingConfiguration.errorHandler(processor.name)::class.java.name,
+                    invocationErrorHandler = eventProcessingConfiguration.listenerInvocationErrorHandler(processor.name)::class.java.name,
+                    interceptors = processor.getInterceptors("interceptors"),
+            )
+
+    private fun toPooledStreamingProcessorInformation(processor: PooledStreamingEventProcessor): EventProcessorInformation {
+        return EventProcessorInformation(
+                name = processor.name,
+                processorType = ProcessorType.POOLED_STREAMING,
+                commonProcessorInformation = commonProcessorInformation(processor),
+                streamingInformation = streamingEventProcessorInformation(processor),
+                pooledStreamingInformation = PooledStreamingEventProcessorInformation(
+                        maxClaimedSegments = processor.getPropertyValue("maxClaimedSegments"),
+                        claimExtensionThreshold = processor.getPropertyValue("claimExtensionThreshold"),
+                        coordinatorExtendsClaims = processor.getPropertyValue<Any>("coordinator")?.getPropertyValue("coordinatorExtendsClaims")
+                ),
+        )
+    }
+
+    private fun toTrackingProcessorInformation(processor: TrackingEventProcessor): EventProcessorInformation {
+        return EventProcessorInformation(
+                name = processor.name,
+                processorType = ProcessorType.TRACKING,
+                commonProcessorInformation = commonProcessorInformation(processor),
+                streamingInformation = streamingEventProcessorInformation(processor),
+                trackingInformation = TrackingEventProcessorInformation(
+                        maxThreadCount = processor.getPropertyValue("maxThreadCount"),
+                        eventAvailabilityTimeout = processor.getPropertyValue("eventAvailabilityTimeout"),
+                        storeTokenBeforeProcessing = processor.getPropertyValue("storeTokenBeforeProcessing"),
+                ),
+        )
+    }
+
+    private fun streamingEventProcessorInformation(processor: StreamingEventProcessor) = StreamingEventProcessorInformation(
+            batchSize = processor.getPropertyValue("batchSize"),
+            tokenClaimInterval = processor.getPropertyValue("tokenClaimInterval"),
+            tokenStoreType = processor.getPropertyType("tokenStore", TokenStore::class.java),
+            supportsReset = processor.supportsReset(),
+            tokenStoreClaimTimeout = processor.getStoreTokenClaimTimeout("tokenStore"),
+    )
+
+    private fun toMessageSource(messageSource: StreamableMessageSource<*>?): MessageSourceInformation {
+        if (messageSource == null) {
+            return UnspecifiedMessageSourceInformation("Unknown")
+        }
+        return when {
+            messageSource is MultiStreamableMessageSource -> MultiStreamableMessageSourceInformation(
+                    messageSource::class.java.name,
+                    messageSource.getPropertyValue<List<StreamableMessageSource<*>>>("eventStreams")?.map { toMessageSource(it) }
+                            ?: emptyList()
+            )
+
+            messageSource is EmbeddedEventStore -> createEmbeddedMessageSourceInformation(messageSource)
+            messageSource::class.java.simpleName == "AxonServerEventStore" -> createAxonServerMessageSourceInfoFromStore(messageSource)
+            messageSource::class.java.simpleName == "AxonIQEventStorageEngine" -> createAxonServerMessageSourceInfoFromStorageEngine(messageSource)
+            else -> UnspecifiedMessageSourceInformation(messageSource::class.java.name)
+        }
+    }
+
+    private fun createAxonServerMessageSourceInfoFromStorageEngine(messageSource: StreamableMessageSource<*>): MessageSourceInformation {
+        val context = messageSource.getPropertyValue<String>("context")
+
+        return AxonServerEventStoreMessageSourceInformation(
+                messageSource::class.java.name,
+                listOfNotNull(context)
+        )
+    }
+
+    private fun createAxonServerMessageSourceInfoFromStore(messageSource: StreamableMessageSource<*>): MessageSourceInformation {
+        val context = messageSource.getPropertyValue<Any>("storageEngine")?.getPropertyValue<String>("context")
+
+        return AxonServerEventStoreMessageSourceInformation(
+                messageSource::class.java.name,
+                listOfNotNull(context)
+        )
+    }
+
+    private fun createEmbeddedMessageSourceInformation(messageSource: EmbeddedEventStore): MessageSourceInformation {
+        return EmbeddedEventStoreMessageSourceInformation(
+                className = messageSource::class.java.name,
+                optimizeEventConsumption = messageSource.getPropertyValue("optimizeEventConsumption"),
+                fetchDelay = messageSource.getPropertyValue<Int?>("producer")?.getPropertyValue<Long>("fetchDelayNanos")?.let { it / 1_000_000 },
+                cachedEvents = messageSource.getPropertyValue<Int?>("producer")?.getPropertyValue("cachedEvents"),
+                cleanupDelay = messageSource.getPropertyValue("cleanupDelayMillis"),
+                eventStorageEngineType = messageSource.getPropertyType("storageEngine")
+
         )
     }
 
@@ -127,7 +224,7 @@ class SetupPayloadCreator(
     private fun queryBusInformation(): QueryBusInformation {
         val bus = configuration.queryBus().unwrapPossiblyDecoratedClass(QueryBus::class.java)
         val axonServer = bus::class.java.name == "org.axonframework.axonserver.connector.query.AxonServerQueryBus"
-        val localSegmentType = if (axonServer) bus.getPropertyTypeNested("localSegment", QueryBus::class.java) else null
+        val localSegmentType = if (axonServer) bus.getPropertyType("localSegment", QueryBus::class.java) else null
         val context = if (axonServer) bus.getPropertyValue<String>("context") else null
         val handlerInterceptors = if (axonServer) {
             bus.getPropertyValue<Any>("localSegment")?.getInterceptors("handlerInterceptors") ?: emptyList()
@@ -188,6 +285,7 @@ class SetupPayloadCreator(
                 is MultiSourceTrackingToken -> token.trackingTokens.values.sumOf {
                     getSizeFromToken(it) ?: 0
                 }
+
                 else -> null
             }
 
@@ -195,7 +293,7 @@ class SetupPayloadCreator(
         val bus = configuration.commandBus().unwrapPossiblyDecoratedClass(CommandBus::class.java)
         val axonServer = bus::class.java.name == "org.axonframework.axonserver.connector.command.AxonServerCommandBus"
         val localSegmentType =
-                if (axonServer) bus.getPropertyTypeNested("localSegment", CommandBus::class.java) else null
+                if (axonServer) bus.getPropertyType("localSegment", CommandBus::class.java) else null
         val context = if (axonServer) bus.getPropertyValue<String>("context") else null
         val handlerInterceptors = if (axonServer) {
             bus.getPropertyValue<Any>("localSegment")?.getInterceptors("handlerInterceptors", "invokerInterceptors")
@@ -233,7 +331,7 @@ class SetupPayloadCreator(
         ).let { it::class.java.name }
     }
 
-    private fun Any.getPropertyTypeNested(fieldName: String, clazz: Class<out Any>): String {
+    private fun Any.getPropertyType(fieldName: String, clazz: Class<out Any>): String {
         return ReflectionUtils.getMemberValue<Any>(
                 ReflectionUtils.fieldsOf(this::class.java).first { it.name == fieldName },
                 this
@@ -242,16 +340,8 @@ class SetupPayloadCreator(
                 .let { it::class.java.name }
     }
 
-    private fun StreamingEventProcessor.getBatchSize(): Int = getPropertyValue("batchSize") ?: -1
-    private fun StreamingEventProcessor.getMessageSource(): String =
-            getPropertyTypeNested("messageSource", EventStore::class.java)
-
-    private fun StreamingEventProcessor.getTokenClaimInterval(): Long = getPropertyValue("tokenClaimInterval") ?: -1
-    private fun StreamingEventProcessor.getStoreTokenStoreType(): String =
-            getPropertyTypeNested("tokenStore", TokenStore::class.java)
-
-    private fun StreamingEventProcessor.getStoreTokenClaimTimeout(): Long = getPropertyValue<Any>("tokenStore")
-            ?.getPropertyValue<TemporalAmount>("claimTimeout")?.let { it.get(ChronoUnit.SECONDS) * 1000 } ?: -1
+    private fun Any.getStoreTokenClaimTimeout(fieldName: String): Long? = getPropertyValue<Any>(fieldName)
+            ?.getPropertyValue<TemporalAmount>("claimTimeout")?.let { it.get(ChronoUnit.SECONDS) * 1000 }
 
 
     private fun Any.getInterceptors(vararg fieldNames: String): List<InterceptorInformation> {
@@ -280,28 +370,6 @@ class SetupPayloadCreator(
         }
         return SerializerInformation(serializer::class.java.name, false)
     }
-
-    private fun StreamingEventProcessor.contexts(): List<String> {
-        val messageSource = getPropertyValue<StreamableMessageSource<*>>("messageSource") ?: return emptyList()
-        val sources = if (messageSource is MultiStreamableMessageSource) {
-            messageSource.getPropertyValue<List<StreamableMessageSource<*>>>("eventStreams") ?: emptyList()
-        } else {
-            listOf(messageSource)
-        }
-        return sources.mapNotNull { toContext(it) }.distinct()
-    }
-
-    private fun toContext(it: StreamableMessageSource<*>): String? {
-        if (it::class.java.simpleName == "AxonServerEventStore") {
-            return it.getPropertyValue<Any>("storageEngine")?.getPropertyValue("context")
-        }
-        if (it::class.java.simpleName == "AxonIQEventStorageEngine") {
-            return it.getPropertyValue("context")
-        }
-        // Fallback
-        return it.getPropertyValue("context")
-    }
-
 }
 
 

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/ProcessorReportCreator.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/ProcessorReportCreator.kt
@@ -91,6 +91,8 @@ class ProcessorReportCreator(
             errorMessage = this.error?.message,
             ingestLatency = metricsRegistry.ingestLatencyForProcessor(name, this.segment.segmentId).getValue(),
             commitLatency = metricsRegistry.commitLatencyForProcessor(name, this.segment.segmentId).getValue(),
+            position = this.currentPosition?.orElse(-1) ?: -1,
+            resetPosition = this.resetPosition?.orElse(-1) ?: -1,
     )
 
     private fun EventProcessor.toProcessingGroupStatuses(): List<ProcessingGroupStatus> =

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/metrics/AxoniqConsoleProcessorInterceptor.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/metrics/AxoniqConsoleProcessorInterceptor.kt
@@ -16,7 +16,7 @@
 
 package io.axoniq.console.framework.eventprocessor.metrics
 
-import io.axoniq.console.framework.messaging.CONSOLE_PROCESSING_GROUP
+import io.axoniq.console.framework.messaging.AxoniqConsoleSpanFactory
 import org.axonframework.eventhandling.EventMessage
 import org.axonframework.messaging.InterceptorChain
 import org.axonframework.messaging.Message
@@ -41,7 +41,9 @@ class AxoniqConsoleProcessorInterceptor(
             return interceptorChain.proceed()
         }
         try {
-            unitOfWork.resources()[CONSOLE_PROCESSING_GROUP] = processorName
+            AxoniqConsoleSpanFactory.onTopLevelSpanIfActive {
+                it.reportProcessorName(processorName)
+            }
             val message = unitOfWork.message
             if (message is EventMessage) {
                 val segment = unitOfWork.resources()["Processor[$processorName]/SegmentId"] as? Int ?: -1

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/SpanMatcher.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/SpanMatcher.kt
@@ -45,6 +45,9 @@ enum class SpanMatcher(val pre49Predicate: Predicate<String>, val from49Predicat
     COMMIT(
             Predicate { name: String -> name.endsWith(".commit") },
             Predicate { name: String -> name == "EventBus.commitEvents" }),
+    SUBCRIBING_EVENT_HANDLER(
+            Predicate { name: String -> name.startsWith("SubscribingEventProcessor[") && name.endsWith(".process")},
+            Predicate { name: String -> name == "EventProcessor.process" }),
     MESSAGE_START(
             Predicate { name: String ->
                 name.endsWith("Bus.handle")

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/extensions.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/extensions.kt
@@ -55,15 +55,14 @@ fun Message<*>.toInformation() = MessageIdentifier(
 
 fun String.toSimpleName() = split(".").last()
 
-fun UnitOfWork<*>.extractHandler(): HandlerStatisticsMetricIdentifier? = try {
-    val processingGroup = resources()[CONSOLE_PROCESSING_GROUP] as? String?
+fun UnitOfWork<*>.extractHandler(declaringClassName: String, processingGroup: String?): HandlerStatisticsMetricIdentifier? = try {
     val isAggregate = message is CommandMessage<*> && isAggregateLifecycleActive()
     val isProcessor = processingGroup != null
 
     val component = when {
         isAggregate -> (AggregateLifecycle.describeCurrentScope() as AggregateScopeDescriptor).type
-        isProcessor -> processingGroup
-        else -> resources()[CONSOLE_DECLARING_CLASS] as String?
+        isProcessor -> processingGroup ?: AxoniqConsoleSpanFactory.currentSpan()?.processorName
+        else -> declaringClassName
     }
     val type = when {
         isAggregate -> HandlerType.Aggregate

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.axoniq.console</groupId>
     <artifactId>console-framework-client-parent</artifactId>
-    <version>1.5.2-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
 
     <modules>
         <module>console-framework-client-api</module>


### PR DESCRIPTION
Changes the structure of event processor information during the setup process, so we can display more information to the user, including:

- Subscribing Event processors
- Different properties based on event processor type
- Improved information about the message source

This has all been done in a backwards-compatible way. The backend will be able to handle all versions of clients, and the UI will change based on whether it's generation 1 or 2