### PR TITLE
Reduce logging to the minimum required for operation

### DIFF
--- a/console-framework-client/src/main/java/io/axoniq/console/framework/application/ApplicationMetricReporter.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/application/ApplicationMetricReporter.kt
@@ -39,12 +39,12 @@ class ApplicationMetricReporter(
     }
 
     override fun onConnectedWithSettings(settings: ClientSettingsV2) {
-        logger.info { "Sending application information every ${settings.applicationReportInterval}ms to AxonIQ console" }
+        logger.debug { "Sending application information every ${settings.applicationReportInterval}ms to AxonIQ console" }
         this.reportTask = executor.scheduleWithFixedDelay({
             try {
                 this.report()
             } catch (e: Exception) {
-                logger.error("Was unable to report application metrics: {}", e.message, e)
+                logger.debug("Was unable to report application metrics: {}", e.message, e)
             }
         }, 0, settings.applicationReportInterval, TimeUnit.MILLISECONDS)
     }

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/client/RSocketHandlerRegistrar.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/client/RSocketHandlerRegistrar.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023. AxonIQ B.V.
+ * Copyright (c) 2022-2024. AxonIQ B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,12 +32,12 @@ class RSocketHandlerRegistrar(
     private val handlers: MutableList<RegisteredRsocketMessageHandler> = mutableListOf()
 
     fun registerHandlerWithoutPayload(route: String, handler: () -> Any) {
-        logger.info("Registered AxonIQ Console handler for route {}", route)
+        logger.debug("Registered AxonIQ Console handler for route {}", route)
         handlers.add(PayloadlessRegisteredRsocketMessageHandler(route, handler))
     }
 
     fun <T> registerHandlerWithPayload(route: String, payloadType: Class<T>, handler: (T) -> Any) {
-        logger.info("Registered AxonIQ Console handler for route {}", route)
+        logger.debug("Registered AxonIQ Console handler for route {}", route)
         handlers.add(PayloadRegisteredRsocketMessageHandler(route, payloadType, handler))
     }
 

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/client/ServerProcessorReporter.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/client/ServerProcessorReporter.kt
@@ -37,12 +37,12 @@ class ServerProcessorReporter(
     }
 
     override fun onConnectedWithSettings(settings: ClientSettingsV2) {
-        logger.info { "Sending processor information every ${settings.processorReportInterval}ms to AxonIQ console" }
+        logger.debug { "Sending processor information every ${settings.processorReportInterval}ms to AxonIQ console" }
         this.reportTask = executor.scheduleWithFixedDelay({
             try {
                 this.report()
             } catch (e: Exception) {
-                logger.error("Was unable to report processor metrics: {}", e.message, e)
+                logger.debug("Was unable to report processor metrics: {}", e.message, e)
             }
         }, 0, settings.processorReportInterval, TimeUnit.MILLISECONDS)
     }

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/EventProcessorManager.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/EventProcessorManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023. AxonIQ B.V.
+ * Copyright (c) 2022-2024. AxonIQ B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,13 +88,13 @@ class EventProcessorManager(
         while (loop < 300) {
             Thread.sleep(100)
             if (processor.processingStatus().containsKey(segmentId)) {
-                logger.info("Processor [${processor.name}] successfully claimed segment [$segmentId] in approx. [${loop * 100}ms].")
+                logger.debug("Processor [${processor.name}] successfully claimed segment [$segmentId] in approx. [${loop * 100}ms].")
                 return true
             }
             loop++
         }
 
-        logger.info("Processor [${processor.name}] failed to claim [$segmentId] in approx. [${loop * 100}ms].")
+        logger.debug("Processor [${processor.name}] failed to claim [$segmentId] in approx. [${loop * 100}ms].")
         return false
     }
 
@@ -106,13 +106,13 @@ class EventProcessorManager(
         while (loop < 300) {
             Thread.sleep(100)
             if (!processor.processingStatus().containsKey(segmentId) || processor.processingStatus().get(segmentId)!!.isErrorState) {
-                logger.info("Processor [${processor.name}] successfully unclaimed segment [$segmentId] in approx. [${loop * 100}ms].")
+                logger.debug("Processor [${processor.name}] successfully unclaimed segment [$segmentId] in approx. [${loop * 100}ms].")
                 return true
             }
             loop++
         }
 
-        logger.info("Processor [${processor.name}] failed to unclaim [$segmentId] in approx. [${loop * 100}ms].")
+        logger.debug("Processor [${processor.name}] failed to unclaim [$segmentId] in approx. [${loop * 100}ms].")
         return false
     }
 

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/RSocketDlqResponder.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/RSocketDlqResponder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023. AxonIQ B.V.
+ * Copyright (c) 2022-2024. AxonIQ B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,12 +61,12 @@ open class RSocketDlqResponder(
     }
 
     private fun handleDeadLetterQuery(request: DeadLetterRequest): DeadLetterResponse {
-        logger.info("Handling AxonIQ Console DEAD_LETTERS query for request [{}]", request)
+        logger.debug("Handling AxonIQ Console DEAD_LETTERS query for request [{}]", request)
         return DeadLetterResponse(deadLetterManager.deadLetters(request.processingGroup, request.offset, request.size))
     }
 
     private fun handleSequenceSizeQuery(request: DeadLetterSequenceSize): Long {
-        logger.info(
+        logger.debug(
             "Handling AxonIQ Console DEAD_LETTER_SEQUENCE_SIZE query for processing group [{}]",
             request.processingGroup
         )
@@ -74,7 +74,7 @@ open class RSocketDlqResponder(
     }
 
     private fun handleDeleteSequenceCommand(request: DeadLetterSequenceDeleteRequest) {
-        logger.info(
+        logger.debug(
             "Handling AxonIQ Console DELETE_FULL_DEAD_LETTER_SEQUENCE command for processing group [{}]",
             request.processingGroup
         )
@@ -82,7 +82,7 @@ open class RSocketDlqResponder(
     }
 
     private fun handleDeleteLetterCommand(request: DeadLetterSingleDeleteRequest) {
-        logger.info(
+        logger.debug(
             "Handling AxonIQ Console DELETE_DEAD_LETTER_IN_SEQUENCE command for processing group [{}]",
             request.processingGroup
         )
@@ -90,7 +90,7 @@ open class RSocketDlqResponder(
     }
 
     private fun handleProcessCommand(request: DeadLetterProcessRequest): Boolean {
-        logger.info("Handling AxonIQ Console DEAD LETTERS query for processing group [{}]", request.processingGroup)
+        logger.debug("Handling AxonIQ Console DEAD LETTERS query for processing group [{}]", request.processingGroup)
         return deadLetterManager.process(request.processingGroup, request.messageIdentifier)
     }
 }

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/RSocketProcessorResponder.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/RSocketProcessorResponder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023. AxonIQ B.V.
+ * Copyright (c) 2022-2024. AxonIQ B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,12 +69,12 @@ open class RSocketProcessorResponder(
     }
 
     private fun handleStart(processorName: String) {
-        logger.info("Handling AxonIQ Console START command for processor [{}]", processorName)
+        logger.debug("Handling AxonIQ Console START command for processor [{}]", processorName)
         eventProcessorManager.start(processorName)
     }
 
     private fun handleStop(processorName: String) {
-        logger.info("Handling AxonIQ Console STOP command for processor [{}]", processorName)
+        logger.debug("Handling AxonIQ Console STOP command for processor [{}]", processorName)
         eventProcessorManager.stop(processorName)
     }
 
@@ -89,7 +89,7 @@ open class RSocketProcessorResponder(
     }
 
     fun handleRelease(processorSegmentId: ProcessorSegmentId) {
-        logger.info(
+        logger.debug(
             "Handling AxonIQ Console RELEASE command for processor [{}] and segment [{}]",
             processorSegmentId.processorName,
             processorSegmentId.segmentId
@@ -98,7 +98,7 @@ open class RSocketProcessorResponder(
     }
 
     private fun handleSplit(processorSegmentId: ProcessorSegmentId): Boolean {
-        logger.info(
+        logger.debug(
             "Handling AxonIQ Console SPLIT command for processor [{}] and segment [{}]",
             processorSegmentId.processorName,
             processorSegmentId.segmentId
@@ -108,7 +108,7 @@ open class RSocketProcessorResponder(
     }
 
     private fun handleMerge(processorSegmentId: ProcessorSegmentId): Boolean {
-        logger.info(
+        logger.debug(
             "Handling AxonIQ Console MERGE command for processor [{}] and segment [{}]",
             processorSegmentId.processorName,
             processorSegmentId.segmentId
@@ -118,12 +118,12 @@ open class RSocketProcessorResponder(
     }
 
     private fun handleReset(resetDecision: ResetDecision) {
-        logger.info("Handling AxonIQ Console RESET command for processor [{}]", resetDecision.processorName)
+        logger.debug("Handling AxonIQ Console RESET command for processor [{}]", resetDecision.processorName)
         eventProcessorManager.resetTokens(resetDecision)
     }
 
     fun handleClaim(processorSegmentId: ProcessorSegmentId): Boolean {
-        logger.info(
+        logger.debug(
             "Handling AxonIQ Console CLAIM command for processor [{}] and segment [{}]",
             processorSegmentId.processorName,
             processorSegmentId.segmentId

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/metrics/AxoniqConsoleProcessorInterceptor.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/metrics/AxoniqConsoleProcessorInterceptor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023. AxonIQ B.V.
+ * Copyright (c) 2022-2024. AxonIQ B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ class AxoniqConsoleProcessorInterceptor(
                 }
             }
         } catch (e: Exception) {
-            logger.info("AxonIQ Console could not register metrics for processor $processorName", e)
+            logger.debug("AxonIQ Console could not register metrics for processor $processorName", e)
         }
         return interceptorChain.proceed()
     }

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/AxoniqConsoleSpanFactory.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/AxoniqConsoleSpanFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023. AxonIQ B.V.
+ * Copyright (c) 2022-2024. AxonIQ B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ class AxoniqConsoleSpanFactory(private val spanMatcherPredicateMap: SpanMatcherP
                 try {
                     block(it)
                 } catch (e: Exception) {
-                    logger.info("Was unable to report AxonIQ Console metrics", e)
+                    logger.debug("Was unable to report AxonIQ Console metrics", e)
                 }
             }
         }
@@ -137,7 +137,7 @@ class AxoniqConsoleSpanFactory(private val spanMatcherPredicateMap: SpanMatcherP
                     }
                 }
             } catch (e: Exception) {
-                logger.info("Could not report metrics for message $handlerMetricIdentifier", e)
+                logger.debug("Could not report metrics for message $handlerMetricIdentifier", e)
             }
         }
 

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/HandlerMetricsRegistry.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/HandlerMetricsRegistry.kt
@@ -57,7 +57,7 @@ class HandlerMetricsRegistry(
     }
 
     override fun onConnectedWithSettings(settings: ClientSettingsV2) {
-        logger.info { "Sending handler information every ${settings.handlerReportInterval}ms to AxonIQ console" }
+        logger.debug { "Sending handler information every ${settings.handlerReportInterval}ms to AxonIQ console" }
         this.reportTask = executor.scheduleAtFixedRate({
             try {
                 val stats = getStats()

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/extensions.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023. AxonIQ B.V.
+ * Copyright (c) 2022-2024. AxonIQ B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ fun UnitOfWork<*>.extractHandler(declaringClassName: String, processingGroup: St
         message = message.toInformation(),
     )
 } catch (e: Exception) {
-    logger.warn("Could not extract handler from AxonIQ Console invocation. Skipping registration of message.", e)
+    logger.debug("Could not extract handler from AxonIQ Console invocation. Skipping registration of message.", e)
     null
 }
 


### PR DESCRIPTION
The rest of the log lines are reduced to debug, so that users can debug their connection if needed. For normal operation, this is not needed.

From now on, we will log:
- Upon connection it will log it's connected and the settings retrieved
- When the connection has been lost
- upon the 5th failure of connection, it will log the connection error once. This is after about 30 seconds.

That's it. We don't want to spam the logs of the users when we deploy. The log during deployments is thus reduced to:

```
Connection to AxonIQ Console set up successfully! Settings: ClientSettingsV2(heartbeatInterval=10000, hear...
This application has lost it's connection to AxonIQ Console. Reconnection will be automatically attempted.
Connection to AxonIQ Console set up successfully! Settings: ClientSettingsV2(heartbeatInterval=10000, hear...
```

When we are offline, it will be similar to:
```
Connection to AxonIQ Console set up successfully! Settings: ClientSettingsV2(heartbeatInterval=10000, heartbeatTimeout=30000, processorReportInterval=2000, handlerReportInte
This application has lost it's connection to AxonIQ Console. Reconnection will be automatically attempted.
Failed to connect to AxonIQ Console. Error: io.netty.channel.AbstractChannel$AnnotatedConnectException: finishConnect(..) failed: Connection refused: localhost/127.0.0.1:700
```