### PR TITLE
Fix bean depending on entire Configuration causing disappearing of me…

### DIFF
--- a/console-framework-client-spring-boot-starter/src/main/java/io/axoniq/console/framework/starter/AxoniqConsoleAutoConfiguration.kt
+++ b/console-framework-client-spring-boot-starter/src/main/java/io/axoniq/console/framework/starter/AxoniqConsoleAutoConfiguration.kt
@@ -18,7 +18,6 @@ package io.axoniq.console.framework.starter
 
 import io.axoniq.console.framework.AxoniqConsoleConfigurerModule
 import io.axoniq.console.framework.messaging.AxoniqConsoleWrappedEventScheduler
-import io.axoniq.console.framework.messaging.HandlerMetricsRegistry
 import io.axoniq.console.framework.messaging.SpanMatcher.Companion.getSpanMatcherPredicateMap
 import io.axoniq.console.framework.messaging.SpanMatcherPredicateMap
 import io.axoniq.console.framework.util.PostProcessHelper
@@ -89,13 +88,12 @@ class AxoniqConsoleAutoConfiguration {
     @ConditionalOnProperty("axoniq.console.credentials", matchIfMissing = false)
     fun axoniqConsoleSpanFactoryPostProcessor(
             spanMatcherPredicateMap: SpanMatcherPredicateMap,
-            configuration: org.axonframework.config.Configuration,
             properties: AxoniqConsoleSpringProperties,
             applicationContext: ApplicationContext
     ): BeanPostProcessor = object : BeanPostProcessor {
         override fun postProcessAfterInitialization(bean: Any, beanName: String): Any {
             return when (bean) {
-                is EventScheduler -> enhanceEventScheduler(bean, configuration, properties, applicationContext)
+                is EventScheduler -> enhanceEventScheduler(bean, properties, applicationContext)
                 else -> PostProcessHelper.enhance(bean, beanName, spanMatcherPredicateMap)
             }
         }
@@ -103,7 +101,6 @@ class AxoniqConsoleAutoConfiguration {
 
     private fun enhanceEventScheduler(
             eventScheduler: EventScheduler,
-            configuration: org.axonframework.config.Configuration,
             properties: AxoniqConsoleSpringProperties,
             applicationContext: ApplicationContext
     ): EventScheduler {
@@ -111,7 +108,7 @@ class AxoniqConsoleAutoConfiguration {
             eventScheduler
         } else {
             getApplicationName(properties, applicationContext)?.let {
-                AxoniqConsoleWrappedEventScheduler(eventScheduler, configuration.getComponent(HandlerMetricsRegistry::class.java), it)
+                AxoniqConsoleWrappedEventScheduler(eventScheduler, it)
             } ?: eventScheduler
         }
     }

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/AxoniqConsoleConfigurerModule.java
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/AxoniqConsoleConfigurerModule.java
@@ -236,7 +236,6 @@ public class AxoniqConsoleConfigurerModule implements ConfigurerModule {
                     EventScheduler.class,
                     c -> new AxoniqConsoleWrappedEventScheduler(
                             eventScheduler,
-                            c.getComponent(HandlerMetricsRegistry.class),
                             applicationName));
         }
 

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/AxoniqConsoleWrappedEventScheduler.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/AxoniqConsoleWrappedEventScheduler.kt
@@ -36,7 +36,6 @@ import java.time.Instant
  */
 class AxoniqConsoleWrappedEventScheduler(
         private val delegate: EventScheduler,
-        private val registry: HandlerMetricsRegistry,
         private val componentName: String,
 ) : EventScheduler, Lifecycle {
     override fun schedule(triggerDateTime: Instant, event: Any): ScheduleToken {
@@ -86,7 +85,7 @@ class AxoniqConsoleWrappedEventScheduler(
     }
 
     private fun reportMessageDispatchedFromOrigin(originName: String, event: Any) {
-        registry.registerMessageDispatchedDuringHandling(
+        HandlerMetricsRegistry.getInstance()?.registerMessageDispatchedDuringHandling(
                 DispatcherStatisticIdentifier(HandlerStatisticsMetricIdentifier(
                         type = HandlerType.Origin,
                         component = originName,


### PR DESCRIPTION
…trics

We had a bean that injects the entire Axon Configuration class, causing eager initialization. And thus, intialization of the metrics while the configuration was still empty. This PR removes that dependency, exactly like was done in https://github.com/AxonIQ/inspector-axon/pull/38


Fixes #77 