### PR TITLE
Fix SetupPayloadCreator crashing due to ClassCastException

### DIFF
--- a/console-framework-client/src/main/java/io/axoniq/console/framework/utils.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/utils.kt
@@ -6,7 +6,7 @@
  * You may obtain a copy of the License at
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
- *
+ *    
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,7 +37,7 @@ private fun <T : Any> T.fieldOfMatchingType(clazz: Class<out T>): Field? {
     // When we reach our own AS-classes, stop unwrapping
     if (this::class.java.name.startsWith("org.axonframework") && this::class.java.simpleName.startsWith("AxonServer")) return null
     return ReflectionUtils.fieldsOf(this::class.java)
-        .firstOrNull { f -> f.type.isAssignableFrom(clazz) }
+        .firstOrNull { f -> clazz.isAssignableFrom(f.type) }
 }
 
 fun <K, V> MutableMap<K, V>.computeIfAbsentWithRetry(key: K, retries: Int = 0, defaultValue: (K) -> V): V {


### PR DESCRIPTION
A ClassCastException caused a crash when using an EmbeddedEventStore. Also found a problem with the unwrapping of decorated FireStarter classes, where the condition in the if was reversed (and thus not unwrapped). This has been fixed.

Proof it works: 

![image](https://github.com/user-attachments/assets/3272583a-5200-4b0a-b7bf-1077a5075437)
