### PR TITLE
Allow pausing of reports and direct logging

### DIFF
--- a/console-framework-client-api/pom.xml
+++ b/console-framework-client-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.axoniq.console</groupId>
         <artifactId>console-framework-client-parent</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/Routes.kt
+++ b/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/Routes.kt
@@ -24,6 +24,12 @@ object Routes {
         const val SETTINGS_V2 = "client-settings-v2"
         // Route on both client and server to receive/send heartbeats
         const val HEARTBEAT = "client-heartbeat"
+        // Request to log something in the application
+        const val LOG = "client-log"
+        // Request to stop sending reports to the server in case a client goes over the limit and credits
+        const val STOP_REPORTS = "client-reporting-stop"
+        // Request to start sending reports again.
+        const val START_REPORTS = "client-reporting-start"
     }
 
     object EventProcessor {

--- a/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/clientIdentification.kt
+++ b/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/clientIdentification.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023. AxonIQ B.V.
+ * Copyright (c) 2022-2024. AxonIQ B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,12 @@ data class SetupPayload(
 )
 
 data class SupportedFeatures(
+        /* Whether the client supports heartbeats to keep the connection alive.*/
         val heartbeat: Boolean? = false,
+        /* Whether the client supports direct logging.*/
+        val logDirect: Boolean? = false,
+        /* Whether the client supports pause/resume of reports.*/
+        val pauseReports: Boolean? = false,
 )
 
 data class Versions(

--- a/console-framework-client-spring-boot-starter/pom.xml
+++ b/console-framework-client-spring-boot-starter/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.axoniq.console</groupId>
         <artifactId>console-framework-client-parent</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/console-framework-client/pom.xml
+++ b/console-framework-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.axoniq.console</groupId>
         <artifactId>console-framework-client-parent</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/application/ApplicationMetricReporter.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/application/ApplicationMetricReporter.kt
@@ -50,7 +50,7 @@ class ApplicationMetricReporter(
     }
 
     private fun report() {
-        client.send(io.axoniq.console.framework.api.Routes.Application.REPORT, reportCreator.createReport()).block()
+        client.sendReport(io.axoniq.console.framework.api.Routes.Application.REPORT, reportCreator.createReport()).block()
     }
 
     override fun onDisconnected() {

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/client/ClientSettingsService.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/client/ClientSettingsService.kt
@@ -16,7 +16,6 @@
 
 package io.axoniq.console.framework.client
 
-import io.axoniq.console.framework.api.ClientSettings
 import io.axoniq.console.framework.api.ClientSettingsV2
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -28,7 +27,7 @@ class ClientSettingsService {
     private var settings: ClientSettingsV2? = null
 
     fun clearSettings() {
-        if(settings != null) {
+        if (settings != null) {
             settings = null
             observers.forEach { it.onDisconnected() }
         }
@@ -36,7 +35,7 @@ class ClientSettingsService {
 
     fun subscribeToSettings(observer: ClientSettingsObserver) {
         this.observers.add(observer)
-        if(settings != null) {
+        if (settings != null) {
             observer.onConnectedWithSettings(settings!!)
         }
     }

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/client/ServerProcessorReporter.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/client/ServerProcessorReporter.kt
@@ -48,7 +48,7 @@ class ServerProcessorReporter(
     }
 
     private fun report() {
-        client.send(io.axoniq.console.framework.api.Routes.EventProcessor.REPORT, processorReportCreator.createReport()).block()
+        client.sendReport(io.axoniq.console.framework.api.Routes.EventProcessor.REPORT, processorReportCreator.createReport()).block()
     }
 
     override fun onDisconnected() {

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/HandlerMetricsRegistry.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/messaging/HandlerMetricsRegistry.kt
@@ -62,7 +62,7 @@ class HandlerMetricsRegistry(
             try {
                 val stats = getStats()
                 logger.debug("Sending metrics: {}", stats)
-                axoniqConsoleRSocketClient.send(io.axoniq.console.framework.api.Routes.MessageFlow.STATS, stats).block()
+                axoniqConsoleRSocketClient.sendReport(io.axoniq.console.framework.api.Routes.MessageFlow.STATS, stats).block()
             } catch (e: Exception) {
                 logger.warn("No metrics could be reported to AxonIQ Console: {}", e.message)
             }

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.axoniq.console</groupId>
     <artifactId>console-framework-client-parent</artifactId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
 
     <modules>
         <module>console-framework-client-api</module>


### PR DESCRIPTION
Adds three calls to the AxonIQ Console client:
- To pause sending reports, used in case of too many clients connected
- To resume the paused reports once capacity frees up
- To log a message directly, instead of via the NotificationList in the call