### PR TITLE
Return `PersistentStreamMessageSourceInformation` during setup-payload when Persistent Streams are used

### DIFF
--- a/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/clientIdentification.kt
+++ b/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/clientIdentification.kt
@@ -177,6 +177,7 @@ data class EventProcessorInformation(
         JsonSubTypes.Type(value = AxonServerEventStoreMessageSourceInformation::class, name = "AxonServer"),
         JsonSubTypes.Type(value = EmbeddedEventStoreMessageSourceInformation::class, name = "Embedded"),
         JsonSubTypes.Type(value = MultiStreamableMessageSourceInformation::class, name = "MultiStreamable"),
+        JsonSubTypes.Type(value = PersistentStreamMessageSourceInformation::class, name = "PersistentStream"),
         JsonSubTypes.Type(value = UnspecifiedMessageSourceInformation::class, name = "Unspecified"),
 )
 interface MessageSourceInformation {
@@ -202,10 +203,19 @@ data class MultiStreamableMessageSourceInformation(
         val sources: List<MessageSourceInformation>,
 ) : MessageSourceInformation
 
+data class PersistentStreamMessageSourceInformation(
+        override val className: String,
+        val context: String?,
+        val streamIdentifier: String?,
+        val batchSize: Int?,
+        val sequencingPolicy: String?,
+        val sequencingPolicyParameters: String?,
+        val query: String?,
+) : MessageSourceInformation
+
 data class UnspecifiedMessageSourceInformation(
         override val className: String,
 ) : MessageSourceInformation
-
 
 enum class ProcessorType {
     SUBSCRIBING,

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/client/SetupPayloadCreator.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/client/SetupPayloadCreator.kt
@@ -204,7 +204,10 @@ class SetupPayloadCreator(
         val batchSize = persistentStreamConnection.getPropertyValue<Int>("batchSize")
 
         val sequencingPolicy = persistentStreamProperties.getPropertyValue<String>("sequencingPolicyName")
-        val sequencingPolicyParameters = persistentStreamProperties.getPropertyValue<String>("sequencingPolicyParameters")
+        val sequencingPolicyParameters = persistentStreamProperties
+                .getPropertyValue<List<String>>("sequencingPolicyParameters")
+                ?.reduceOrNull { acc, s -> "$acc,$s" }
+                ?: "none"
         val query = persistentStreamProperties.getPropertyValue<String>("filter")
 
         return PersistentStreamMessageSourceInformation(


### PR DESCRIPTION
This pull request ensures that when a user has persistent streams configured, the `SetupPayloadCreator` will return a dedicated `MessageSourceInformation` instance.

This new implementation is the `PersistentStreamMessageSourceInformation`, containing all static information of a persistent stream.
Hence, the `streamName` and `segmentCount` **are not** included in the setup-payload.
That information should be provided on the Processors page but will follow in another pull request.

Next to adding the `PersistentStreamMessageSourceInformation`, I have adjusted the `SetupPayloadCreator` to invoke a specific `mapSubscribableMessageSource` to map the `SubscribableMessageSource` (which may be a persistent streams implementation) to a `MessageSourceInformation`.
Before this pull request, the `SetupPayloadCreator` simply assumed the message source was an implementation of the `StreamableMessageSource` at all times.
This is, obviously, not the case when a `PersistentStreamMessageSource` is set for a `SubscribingEventProcessor`.