### PR TITLE
Add processing latency to the client

### DIFF
--- a/console-framework-client-api/pom.xml
+++ b/console-framework-client-api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022-2024. AxonIQ B.V.
+  ~ Copyright (c) 2022-2025. AxonIQ B.V.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.axoniq.console</groupId>
         <artifactId>console-framework-client-parent</artifactId>
-        <version>1.8.2-SNAPSHOT</version>
+        <version>1.9.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/eventProcessorApi.kt
+++ b/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/eventProcessorApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023. AxonIQ B.V.
+ * Copyright (c) 2022-2025. AxonIQ B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ data class SegmentStatus(
         val errorMessage: String?,
         val ingestLatency: Double?,
         val commitLatency: Double?,
+        val processingLatency: Double?,
         val position: Long? = -1,
         val resetPosition: Long? = -1,
 )

--- a/console-framework-client-spring-boot-starter/pom.xml
+++ b/console-framework-client-spring-boot-starter/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022-2024. AxonIQ B.V.
+  ~ Copyright (c) 2022-2025. AxonIQ B.V.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.axoniq.console</groupId>
         <artifactId>console-framework-client-parent</artifactId>
-        <version>1.8.2-SNAPSHOT</version>
+        <version>1.9.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/console-framework-client/pom.xml
+++ b/console-framework-client/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022-2024. AxonIQ B.V.
+  ~ Copyright (c) 2022-2025. AxonIQ B.V.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.axoniq.console</groupId>
         <artifactId>console-framework-client-parent</artifactId>
-        <version>1.8.2-SNAPSHOT</version>
+        <version>1.9.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/ProcessorReportCreator.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/ProcessorReportCreator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023. AxonIQ B.V.
+ * Copyright (c) 2022-2025. AxonIQ B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,6 +121,7 @@ class ProcessorReportCreator(
             errorMessage = this.error?.message,
             ingestLatency = metricsRegistry.ingestLatencyForProcessor(name, this.segment.segmentId).getValue(),
             commitLatency = metricsRegistry.commitLatencyForProcessor(name, this.segment.segmentId).getValue(),
+            processingLatency = metricsRegistry.processingMessageLatencyForProcessor(name, this.segment.segmentId)?.toDouble() ?: -1.0,
             position = this.currentPosition?.orElse(-1) ?: -1,
             resetPosition = this.resetPosition?.orElse(-1) ?: -1,
     )

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022-2024. AxonIQ B.V.
+  ~ Copyright (c) 2022-2025. AxonIQ B.V.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 
     <groupId>io.axoniq.console</groupId>
     <artifactId>console-framework-client-parent</artifactId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
 
     <modules>
         <module>console-framework-client-api</module>


### PR DESCRIPTION
Measures the time between the currently processing message and the current clock. This will allow us to detect stalled segments, as this time will increase for every report.

Before, we only had ingest latency, but this will no longer show after 30 minutes. In addition, the nature of that metric does not allow it to increase. It will remain fixed during the processing.


![image](https://github.com/user-attachments/assets/aed3f6a4-1d6f-4df7-a20c-78d29ae8bbce)
