### PR TITLE
Thread dumps of applications connected to the AxonIQ Console

### DIFF
--- a/console-framework-client-api/pom.xml
+++ b/console-framework-client-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.axoniq.console</groupId>
         <artifactId>console-framework-client-parent</artifactId>
-        <version>1.9.0-SNAPSHOT</version>
+        <version>1.9.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/Routes.kt
+++ b/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/Routes.kt
@@ -30,6 +30,8 @@ object Routes {
         const val STOP_REPORTS = "client-reporting-stop"
         // Request to start sending reports again.
         const val START_REPORTS = "client-reporting-start"
+        // Request to send a thread dump
+        const val THREAD_DUMP = "client-thread-dump"
     }
 
     object EventProcessor {

--- a/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/clientIdentification.kt
+++ b/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/clientIdentification.kt
@@ -101,6 +101,8 @@ data class SupportedFeatures(
         val logDirect: Boolean? = false,
         /* Whether the client supports pause/resume of reports.*/
         val pauseReports: Boolean? = false,
+        /* Whether the client supports thread dumps.*/
+        val threadDump: Boolean? = false
 )
 
 data class Versions(

--- a/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/threadDumpApi.kt
+++ b/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/threadDumpApi.kt
@@ -1,0 +1,16 @@
+package io.axoniq.console.framework.api
+
+data class ThreadDumpEntry(
+        val instanceName: String,
+        val threadName: String,
+        val threadDump: String,
+)
+
+data class ThreadDumpResult(
+        val timestamp: Long,
+        val threadDumpEntries: List<ThreadDumpEntry>
+)
+
+data class ThreadDumpQuery(
+        val instanceName: String
+)

--- a/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/threadDumpApi.kt
+++ b/console-framework-client-api/src/main/java/io/axoniq/console/framework/api/threadDumpApi.kt
@@ -1,9 +1,9 @@
 package io.axoniq.console.framework.api
 
 data class ThreadDumpEntry(
-        val instanceName: String,
-        val threadName: String,
-        val threadDump: String,
+        val instance: String,
+        val thread: String,
+        val trace: String,
 )
 
 data class ThreadDumpResult(
@@ -12,5 +12,5 @@ data class ThreadDumpResult(
 )
 
 data class ThreadDumpQuery(
-        val instanceName: String
+        val instance: String
 )

--- a/console-framework-client-spring-boot-starter/pom.xml
+++ b/console-framework-client-spring-boot-starter/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.axoniq.console</groupId>
         <artifactId>console-framework-client-parent</artifactId>
-        <version>1.9.0-SNAPSHOT</version>
+        <version>1.9.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/console-framework-client/pom.xml
+++ b/console-framework-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.axoniq.console</groupId>
         <artifactId>console-framework-client-parent</artifactId>
-        <version>1.9.0-SNAPSHOT</version>
+        <version>1.9.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/AxoniqConsoleConfigurerModule.java
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/AxoniqConsoleConfigurerModule.java
@@ -19,6 +19,8 @@ package io.axoniq.console.framework;
 import io.axoniq.console.framework.application.ApplicationMetricRegistry;
 import io.axoniq.console.framework.application.ApplicationMetricReporter;
 import io.axoniq.console.framework.application.ApplicationReportCreator;
+import io.axoniq.console.framework.application.ApplicationThreadDumpProvider;
+import io.axoniq.console.framework.application.RSocketThreadDumpResponder;
 import io.axoniq.console.framework.client.AxoniqConsoleRSocketClient;
 import io.axoniq.console.framework.client.ClientSettingsService;
 import io.axoniq.console.framework.client.RSocketHandlerRegistrar;
@@ -218,9 +220,17 @@ public class AxoniqConsoleConfigurerModule implements ConfigurerModule {
                                            dlqDiagnosticsWhitelist,
                                            managementTaskExecutor
                                    ))
+                .registerComponent(ApplicationThreadDumpProvider.class,
+                                   c -> new ApplicationThreadDumpProvider()
+                )
                 .registerComponent(RSocketDlqResponder.class,
                                    c -> new RSocketDlqResponder(
                                            c.getComponent(DeadLetterManager.class),
+                                           c.getComponent(RSocketHandlerRegistrar.class)
+                                   ))
+                .registerComponent(RSocketThreadDumpResponder.class,
+                                   c -> new RSocketThreadDumpResponder(
+                                           c.getComponent(ApplicationThreadDumpProvider.class),
                                            c.getComponent(RSocketHandlerRegistrar.class)
                                    ))
                 .eventProcessing()
@@ -248,6 +258,7 @@ public class AxoniqConsoleConfigurerModule implements ConfigurerModule {
             c.getComponent(RSocketProcessorResponder.class);
             c.getComponent(RSocketDlqResponder.class);
             c.getComponent(HandlerMetricsRegistry.class);
+            c.getComponent(RSocketThreadDumpResponder.class);
         });
 
         configurer.onStart(() -> {

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/application/ApplicationThreadDumpProvider.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/application/ApplicationThreadDumpProvider.kt
@@ -6,12 +6,12 @@ import java.lang.management.ManagementFactory
 class ApplicationThreadDumpProvider() {
     private val threadBean = ManagementFactory.getThreadMXBean()
 
-    fun collectThreadDumps(instanceName: String): ThreadDumpResult {
+    fun collectThreadDumps(instance: String): ThreadDumpResult {
         val threadDumpEntries = threadBean.dumpAllThreads(true, true).map { threadInfo ->
             ThreadDumpEntry(
-                    instanceName = instanceName,
-                    threadName = threadInfo.threadName,
-                    threadDump = threadInfo.toString()
+                    instance = instance,
+                    thread = threadInfo.threadName,
+                    trace = threadInfo.toString()
             )
         }
         return ThreadDumpResult(timestamp = System.currentTimeMillis(), threadDumpEntries = threadDumpEntries)

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/application/ApplicationThreadDumpProvider.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/application/ApplicationThreadDumpProvider.kt
@@ -1,0 +1,19 @@
+package io.axoniq.console.framework.application
+import io.axoniq.console.framework.api.ThreadDumpEntry
+import io.axoniq.console.framework.api.ThreadDumpResult
+import java.lang.management.ManagementFactory
+
+class ApplicationThreadDumpProvider() {
+    private val threadBean = ManagementFactory.getThreadMXBean()
+
+    fun collectThreadDumps(instanceName: String): ThreadDumpResult {
+        val threadDumpEntries = threadBean.dumpAllThreads(true, true).map { threadInfo ->
+            ThreadDumpEntry(
+                    instanceName = instanceName,
+                    threadName = threadInfo.threadName,
+                    threadDump = threadInfo.toString()
+            )
+        }
+        return ThreadDumpResult(timestamp = System.currentTimeMillis(), threadDumpEntries = threadDumpEntries)
+    }
+}

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/application/RSocketThreadDumpResponder.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/application/RSocketThreadDumpResponder.kt
@@ -1,0 +1,31 @@
+package io.axoniq.console.framework.application
+
+import io.axoniq.console.framework.api.*
+import io.axoniq.console.framework.client.RSocketHandlerRegistrar
+import org.axonframework.lifecycle.Lifecycle
+import org.axonframework.lifecycle.Phase
+import org.slf4j.LoggerFactory
+
+open class RSocketThreadDumpResponder (
+        private val applicationThreadDumpProvider: ApplicationThreadDumpProvider,
+        private val registrar: RSocketHandlerRegistrar
+) : Lifecycle {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    override fun registerLifecycleHandlers(registry: Lifecycle.LifecycleRegistry) {
+        registry.onStart(Phase.EXTERNAL_CONNECTIONS, this::start)
+    }
+
+    fun start() {
+        registrar.registerHandlerWithPayload(
+                Routes.Management.THREAD_DUMP,
+                ThreadDumpQuery::class.java,
+                this::handleThreadDumpQuery
+        )
+    }
+
+    private fun handleThreadDumpQuery(query: ThreadDumpQuery): ThreadDumpResult {
+        logger.debug("Handling AxonIQ Console THREAD_DUMP query for request [{}]", query)
+        return applicationThreadDumpProvider.collectThreadDumps(query.instanceName)
+    }
+}

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/application/RSocketThreadDumpResponder.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/application/RSocketThreadDumpResponder.kt
@@ -26,6 +26,6 @@ open class RSocketThreadDumpResponder (
 
     private fun handleThreadDumpQuery(query: ThreadDumpQuery): ThreadDumpResult {
         logger.debug("Handling AxonIQ Console THREAD_DUMP query for request [{}]", query)
-        return applicationThreadDumpProvider.collectThreadDumps(query.instanceName)
+        return applicationThreadDumpProvider.collectThreadDumps(query.instance)
     }
 }

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/client/SetupPayloadCreator.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/client/SetupPayloadCreator.kt
@@ -52,7 +52,8 @@ class SetupPayloadCreator(
                 versions = versionInformation(),
                 upcasters = upcasters(),
                 features = SupportedFeatures(
-                        heartbeat = true
+                        heartbeat = true,
+                        threadDump = true,
                 )
         )
     }

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.axoniq.console</groupId>
     <artifactId>console-framework-client-parent</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.9.1-SNAPSHOT</version>
 
     <modules>
         <module>console-framework-client-api</module>


### PR DESCRIPTION
We should allow users to be able to take a thread dump of their applications currently connected to the AxonIQ Console

An issue: https://github.com/AxonIQ/console-web/issues/571