### PR TITLE
Correct latency metrics in AxonIQ Console

### DIFF
--- a/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/metrics/AxoniqConsoleProcessorInterceptor.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/metrics/AxoniqConsoleProcessorInterceptor.kt
@@ -49,17 +49,18 @@ class AxoniqConsoleProcessorInterceptor(
                 it.reportProcessorName(processorName)
             }
             val segment = unitOfWork.resources()["Processor[$processorName]/SegmentId"] as? Int ?: -1
+            val ingestTimestamp = Instant.now()
             processorMetricsRegistry.registerIngested(
                     processorName,
                     segment,
-                    ChronoUnit.NANOS.between(message.timestamp, Instant.now())
+                    ChronoUnit.NANOS.between(message.timestamp, ingestTimestamp)
             )
             if (unitOfWork !is BatchingUnitOfWork<*> || unitOfWork.isFirstMessage) {
                 unitOfWork.afterCommit {
                     processorMetricsRegistry.registerCommitted(
                             processorName,
                             segment,
-                            ChronoUnit.NANOS.between(message.timestamp, Instant.now())
+                            ChronoUnit.NANOS.between(ingestTimestamp, Instant.now())
                     )
                 }
             }

--- a/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/metrics/ProcessorMetricsRegistry.kt
+++ b/console-framework-client/src/main/java/io/axoniq/console/framework/eventprocessor/metrics/ProcessorMetricsRegistry.kt
@@ -48,7 +48,7 @@ class ProcessorMetricsRegistry {
         } finally {
             val uow = CurrentUnitOfWork.get()
             if(uow !is BatchingUnitOfWork || uow.isFirstMessage) {
-                uow.afterCommit {
+                uow.onCleanup {
                     getProcessingLatencySegmentMap(processor)
                             .remove(segment)
                 }
@@ -81,7 +81,7 @@ class ProcessorMetricsRegistry {
             .computeIfAbsentWithRetry(processor) { ConcurrentHashMap() }
 
     class ExpiringLatencyValue(
-        private val expiryTime: Long = 30 * 60 * 1000 // Default to 1 hour
+        private val expiryTime: Long = 2 * 60 * 1000 // Default to 2 minutes
     ) {
         private val clock = Clock.systemUTC()
         private val value: AtomicReference<Double> = AtomicReference(-1.0)


### PR DESCRIPTION
First, we set the expiry time of ingest and commit latencies to two minutes, instead of 30 minutes. This prevents alarms from triggering and statistics to be strange. I think 2 minutes is a balanced approach; generally batches will take under 10 seconds, so 2 minutes is already more than enough.

Second, we will now clean up the current message on cleanup, not on after commit. This will prevent hanging current latencies on errors.

Third, the commit latency is now the time between ingest of the first message of the batch and the commit time of it. As such, this represents the batch time.