### PR TITLE
Change CBOR encoding strategy order to properly detect Jackson 2

### DIFF
--- a/framework-client-messaging/src/main/java/io/axoniq/platform/framework/AxoniqPlatformConfigurerEnhancer.java
+++ b/framework-client-messaging/src/main/java/io/axoniq/platform/framework/AxoniqPlatformConfigurerEnhancer.java
@@ -223,29 +223,10 @@ public class AxoniqPlatformConfigurerEnhancer implements ConfigurationEnhancer {
     }
 
     /**
-     * Checks the classpath for Jackson 2 or Jackson 3 and its requiremenets for this application.
+     * Checks the classpath for Jackson 2 or Jackson 3 and its requirements for this application.
      * Will fail to create the component if neither is there, or if one is present and doesn't have the right modules.
      */
     private static RSocketPayloadEncodingStrategy createJackson2Or3EncodingStrategy() {
-        try {
-            Class.forName("tools.jackson.databind.ObjectMapper");
-            try {
-                Class.forName("tools.jackson.dataformat.cbor.CBORMapper");
-                try {
-                    Class.forName("tools.jackson.module.kotlin.KotlinModule");
-                    return new CborJackson3EncodingStrategy();
-                } catch (ClassNotFoundException e) {
-                    throw new IllegalArgumentException(
-                            "Found Jackson 3 on the classpath, but can not find the KotlinModule. Please add the tools.jackson.module:jackson-module-kotlin dependency to your project");
-                }
-            } catch (ClassNotFoundException e) {
-                throw new IllegalArgumentException(
-                        "Found Jackson 3 on the classpath, but cannot find the CBOR dataformat. Please add the tools.jackson.dataformat:jackson-dataformat-cbor dependency to your project.");
-            }
-        } catch (ClassNotFoundException e) {
-            // Do nothing, Jackson 3 is not on the classpath. Continue to check for 2
-        }
-
         try {
             Class.forName("com.fasterxml.jackson.databind.ObjectMapper");
             try {
@@ -262,6 +243,25 @@ public class AxoniqPlatformConfigurerEnhancer implements ConfigurationEnhancer {
             } catch (ClassNotFoundException e) {
                 throw new IllegalArgumentException(
                         "Found Jackson 2 on the classpath, but cannot find the CBOR dataformat. Please add the com.fasterxml.jackson.dataformat:jackson-dataformat-cbor dependency to your project.");
+            }
+        } catch (ClassNotFoundException e) {
+            // Do nothing, Jackson 2 is not on the classpath. Continue to check for 3
+        }
+
+        try {
+            Class.forName("tools.jackson.databind.ObjectMapper");
+            try {
+                Class.forName("tools.jackson.dataformat.cbor.CBORMapper");
+                try {
+                    Class.forName("tools.jackson.module.kotlin.KotlinModule");
+                    return new CborJackson3EncodingStrategy();
+                } catch (ClassNotFoundException e) {
+                    throw new IllegalArgumentException(
+                            "Found Jackson 3 on the classpath, but can not find the KotlinModule. Please add the tools.jackson.module:jackson-module-kotlin dependency to your project");
+                }
+            } catch (ClassNotFoundException e) {
+                throw new IllegalArgumentException(
+                        "Found Jackson 3 on the classpath, but cannot find the CBOR dataformat. Please add the tools.jackson.dataformat:jackson-dataformat-cbor dependency to your project.");
             }
         } catch (ClassNotFoundException e) {
             throw new IllegalArgumentException(


### PR DESCRIPTION
Currently, the system checks for Jackson 3 before Jackson 2. Because the Jackson 3 modules are included as standard (non-optional) dependencies in the project, the classpath check for Jackson 3 always evaluates to `true`. 

Consequently, the strategy check never fails, and the framework never reaches the condition to verify if the user is actually running Jackson 2. This can result in the wrong encoding strategy being applied for users who rely on Jackson 2.