### PR TITLE
Improve auth logging errors

### DIFF
--- a/framework-client-messaging/src/main/java/io/axoniq/platform/framework/client/AxoniqConsoleRSocketClient.kt
+++ b/framework-client-messaging/src/main/java/io/axoniq/platform/framework/client/AxoniqConsoleRSocketClient.kt
@@ -390,13 +390,12 @@ class AxoniqConsoleRSocketClient(
                 }
                 .onErrorMap {
                     if (it.message?.contains("Access Denied") == true) {
+                        logger.error("Was unable to connect to Axoniq Platform due to invalid authentication! Make sure the access token is correct.")
                         IllegalStateException("Was unable to connect to Axoniq Platform due to invalid authentication! Make sure the access token is correct.")
                     } else {
+                        logger.error("Could not connect to Axoniq Platform due to connection error: ${it.message}", it)
                         it
                     }
-                }
-                .doOnError {
-                    logger.error("Could not connect to Axoniq Platform", it)
                 }
     }
 


### PR DESCRIPTION
When the user doesn't have the right auth details, it's shown as huge stacktraces. This gives no additional information, and hides other important messages, such as the license.

This PR changes the logging a tiny bit, no longer logging huge stacktraces on known auth errors.