### PR TITLE
Release: 2.0.4 for Axon Framework 5

### DIFF
--- a/framework-client-all/pom.xml
+++ b/framework-client-all/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.axoniq.platform</groupId>
         <artifactId>framework-client-parent</artifactId>
-        <version>2.0.4-SNAPSHOT</version>
+        <version>2.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-client-api/pom.xml
+++ b/framework-client-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.axoniq.platform</groupId>
         <artifactId>framework-client-parent</artifactId>
-        <version>2.0.4-SNAPSHOT</version>
+        <version>2.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-client-eventsourcing/pom.xml
+++ b/framework-client-eventsourcing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.axoniq.platform</groupId>
         <artifactId>framework-client-parent</artifactId>
-        <version>2.0.4-SNAPSHOT</version>
+        <version>2.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-client-messaging/pom.xml
+++ b/framework-client-messaging/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.axoniq.platform</groupId>
         <artifactId>framework-client-parent</artifactId>
-        <version>2.0.4-SNAPSHOT</version>
+        <version>2.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-client-messaging/src/main/java/io/axoniq/platform/framework/AxoniqPlatformConfigurerEnhancer.java
+++ b/framework-client-messaging/src/main/java/io/axoniq/platform/framework/AxoniqPlatformConfigurerEnhancer.java
@@ -53,7 +53,6 @@ import org.axonframework.messaging.eventhandling.processing.streaming.pooled.Poo
 import org.axonframework.messaging.eventhandling.processing.subscribing.SubscribingEventProcessorModule;
 import org.axonframework.messaging.queryhandling.QueryBus;
 import org.axonframework.messaging.queryhandling.distributed.DistributedQueryBusConfiguration;
-import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/framework-client-modelling/pom.xml
+++ b/framework-client-modelling/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.axoniq.platform</groupId>
         <artifactId>framework-client-parent</artifactId>
-        <version>2.0.4-SNAPSHOT</version>
+        <version>2.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-client-spring-boot-starter/pom.xml
+++ b/framework-client-spring-boot-starter/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.axoniq.platform</groupId>
         <artifactId>framework-client-parent</artifactId>
-        <version>2.0.4-SNAPSHOT</version>
+        <version>2.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.axoniq.platform</groupId>
     <artifactId>framework-client-parent</artifactId>
-    <version>2.0.4-SNAPSHOT</version>
+    <version>2.0.4</version>
 
     <modules>
         <module>framework-client-api</module>
@@ -60,7 +60,7 @@
         <kotlin.version>2.2.20</kotlin.version>
         <dokka.version>2.1.0</dokka.version>
 
-        <axon.version>5.1.0-SNAPSHOT</axon.version>
+        <axon.version>5.0.4</axon.version>
         <jackson.version>3.1.0</jackson.version>
         <jackson-annotations.version>2.21</jackson-annotations.version>
         <spring-boot.version>3.5.7</spring-boot.version>


### PR DESCRIPTION
This PR releases framework client 2.0.4 for Axon Framework 4. Axon Framework has been downgraded to `5.0.4` to depend on the latest recommended Axon Framework library (non-RC).